### PR TITLE
Fix: DNS record deletion issue in MAAS provider

### DIFF
--- a/maas/resource_maas_dns_record.go
+++ b/maas/resource_maas_dns_record.go
@@ -188,12 +188,13 @@ func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		if err := client.DNSResource.Delete(id); err != nil {
-			return diag.FromErr(err)
-		}
+		ip := d.Get("data").(string)
 		for _, ipAddress := range dnsResource.IPAddresses {
-			if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil {
-				return diag.FromErr(err)
+			if ipAddress.IP.String() == ip {
+				if err := client.DNSResource.Delete(id); err != nil {
+					return diag.FromErr(err)
+				}
+				break
 			}
 		}
 	} else {


### PR DESCRIPTION
This pull request addresses an issue in the MAAS Terraform provider where deleting a DNS record inadvertently removes other DNS records pointing to the same IP address. The changes ensure that only the specified DNS record is deleted, preventing the unintended removal of other records.

**Changes Made**
Conditional IP Address Check:

Added a check to ensure the DNS resource's IP address matches the IP address of the record to be deleted. This ensures only the correct record is targeted for deletion.
Avoid IP Address Release:

Modified the deletion logic to avoid releasing the IP address. This prevents the removal of other records that share the same IP address.

fix - https://github.com/maas/terraform-provider-maas/issues/195