### PR TITLE
ci: fix goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,4 +57,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,4 @@
+version: 2
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:


### PR DESCRIPTION
ci: fix goreleaser config

Fixup after updating goreleaser/goreleaser-action from 5 to 6
https://github.com/canonical/terraform-provider-maas/commit/a46577a90b66c4e9429f085896dd621c9b3b7e51

Add v2 version to the goreleaser config file.
https://goreleaser.com/errors/version/#unsupported-configuration-version

Based on goreleaser [deprecations](https://goreleaser.com/deprecations/#changelogskip) `changelog.skip` is replaced by `changelog.disable`.
