### PR TITLE
chore: update Go module to Go 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ References:
 ## Requirements
 
 - [Terraform](https://www.terraform.io/downloads.html) >= 1.4.x
-- [Go](https://golang.org/doc/install) >= 1.20
+- [Go](https://golang.org/doc/install) >= 1.21
 
 ## Build The Provider
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-maas
 
-go 1.20
+go 1.21
 
 require (
 	github.com/bflad/tfproviderlint v0.30.0


### PR DESCRIPTION
Each major Go release is supported until there are two newer major releases [0].

[0]: https://go.dev/doc/devel/release#policy