### PR TITLE
fix: correctly parse vlan field of VLAN interfaces

### DIFF
--- a/maas/resource_maas_network_interface_bond_test.go
+++ b/maas/resource_maas_network_interface_bond_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testAccMaasNetworkInterfaceBond(name string, machine string, fabric string) string {
+func testAccMaasNetworkInterfaceBond(name string, machine string, fabric string, mtu int) string {
 	return fmt.Sprintf(`
 data "maas_fabric" "default" {
 	name = "%s"
@@ -56,12 +56,12 @@ resource "maas_network_interface_bond" "test" {
 	bond_updelay          = 1
 	bond_xmit_hash_policy = "layer2"
 	mac_address           = "01:12:34:56:78:9A"
-	mtu                   = 9000
+	mtu                   = %d
 	parents               = [maas_network_interface_physical.nic1.name, maas_network_interface_physical.nic2.name]
 	tags                  = ["tag1", "tag2"]
 	vlan                  = data.maas_vlan.default.id
 }
-`, fabric, machine, name)
+`, fabric, machine, name, mtu)
 }
 
 func TestAccResourceMaasNetworkInterfaceBond_basic(t *testing.T) {
@@ -83,7 +83,6 @@ func TestAccResourceMaasNetworkInterfaceBond_basic(t *testing.T) {
 		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "bond_updelay", "1"),
 		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "bond_xmit_hash_policy", "layer2"),
 		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "mac_address", "01:12:34:56:78:9A"),
-		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "mtu", "9000"),
 		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "parents.#", "2"),
 		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "parents.0", "enp109s0f0"),
 		resource.TestCheckResourceAttr("maas_network_interface_bond.test", "parents.1", "enp109s0f1"),
@@ -100,8 +99,15 @@ func TestAccResourceMaasNetworkInterfaceBond_basic(t *testing.T) {
 		ErrorCheck:   func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMaasNetworkInterfaceBond(name, machine, fabric),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Config: testAccMaasNetworkInterfaceBond(name, machine, fabric, 1500),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks, resource.TestCheckResourceAttr("maas_network_interface_bond.test", "mtu", "1500"))...),
+			},
+			// Test update
+			{
+				Config: testAccMaasNetworkInterfaceBond(name, machine, fabric, 9000),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks, resource.TestCheckResourceAttr("maas_network_interface_bond.test", "mtu", "9000"))...),
 			},
 			// Test import
 			{

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func testAccMaasNetworkInterfacePhysical(name string, machine string, fabric string) string {
+func testAccMaasNetworkInterfacePhysical(name string, machine string, fabric string, mtu int) string {
 	return fmt.Sprintf(`
 data "maas_fabric" "default" {
 	name = "%s"
@@ -34,11 +34,11 @@ resource "maas_network_interface_physical" "test" {
 	machine     = data.maas_machine.machine.id
 	name        = "%s"
 	mac_address = "01:12:34:56:78:9A"
-	mtu         = 9000
+	mtu         = %d
 	tags        = ["tag1", "tag2"]
 	vlan        = data.maas_vlan.default.id
   }
-`, fabric, machine, name)
+`, fabric, machine, name, mtu)
 }
 
 func TestAccResourceMaasNetworkInterfacePhysical_basic(t *testing.T) {
@@ -52,7 +52,6 @@ func TestAccResourceMaasNetworkInterfacePhysical_basic(t *testing.T) {
 		testAccMaasNetworkInterfacePhysicalCheckExists("maas_network_interface_physical.test", &networkInterfacePhysical),
 		resource.TestCheckResourceAttr("maas_network_interface_physical.test", "name", name),
 		resource.TestCheckResourceAttr("maas_network_interface_physical.test", "mac_address", "01:12:34:56:78:9A"),
-		resource.TestCheckResourceAttr("maas_network_interface_physical.test", "mtu", "9000"),
 		resource.TestCheckResourceAttr("maas_network_interface_physical.test", "tags.#", "2"),
 		resource.TestCheckResourceAttr("maas_network_interface_physical.test", "tags.0", "tag1"),
 		resource.TestCheckResourceAttr("maas_network_interface_physical.test", "tags.1", "tag2"),
@@ -66,8 +65,15 @@ func TestAccResourceMaasNetworkInterfacePhysical_basic(t *testing.T) {
 		ErrorCheck:   func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMaasNetworkInterfacePhysical(name, machine, fabric),
-				Check:  resource.ComposeTestCheckFunc(checks...),
+				Config: testAccMaasNetworkInterfacePhysical(name, machine, fabric, 1500),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks, resource.TestCheckResourceAttr("maas_network_interface_physical.test", "mtu", "1500"))...),
+			},
+			// Test update
+			{
+				Config: testAccMaasNetworkInterfacePhysical(name, machine, fabric, 9000),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks, resource.TestCheckResourceAttr("maas_network_interface_physical.test", "mtu", "9000"))...),
 			},
 			// Test import
 			{

--- a/maas/resource_maas_network_interface_vlan.go
+++ b/maas/resource_maas_network_interface_vlan.go
@@ -87,7 +87,7 @@ func resourceNetworkInterfaceVlanCreate(ctx context.Context, d *schema.ResourceD
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	vlan, err := getVlan(client, fabric.ID, fmt.Sprintf("%v", d.Get("vlan").(int)))
+	vlan, err := getVlan(client, fabric.ID, strconv.Itoa(d.Get("vlan").(int)))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -136,7 +136,7 @@ func resourceNetworkInterfaceVlanRead(ctx context.Context, d *schema.ResourceDat
 		"vlan":   networkInterface.VLAN.ID,
 	}
 	if _, ok := d.GetOk("fabric"); !ok {
-		tfState["fabric"] = fmt.Sprintf("%v", networkInterface.VLAN.FabricID)
+		tfState["fabric"] = strconv.Itoa(networkInterface.VLAN.FabricID)
 	}
 	if err := setTerraformState(d, tfState); err != nil {
 		return diag.FromErr(err)
@@ -144,6 +144,7 @@ func resourceNetworkInterfaceVlanRead(ctx context.Context, d *schema.ResourceDat
 
 	return nil
 }
+
 func resourceNetworkInterfaceVlanUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*client.Client)
 
@@ -167,7 +168,7 @@ func resourceNetworkInterfaceVlanUpdate(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	vlan, err := getVlan(client, fabric.ID, d.Get("vlan").(string))
+	vlan, err := getVlan(client, fabric.ID, strconv.Itoa(d.Get("vlan").(int)))
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
- Parse `vlan` field as integer rather than string
- Add acceptance test to check the context update of all interface types

Resolves GH: #206 