### PR TITLE
fix: tag should query MAAS machines once

### DIFF
--- a/maas/resource_maas_tag.go
+++ b/maas/resource_maas_tag.go
@@ -192,14 +192,30 @@ func getTagTFMachinesSystemIDs(client *client.Client, d *schema.ResourceData) ([
 	if !ok {
 		return nil, nil
 	}
-	machinesSystemIDs := []string{}
-	for _, machineIdentifier := range convertToStringSlice(p.(*schema.Set).List()) {
-		machine, err := getMachine(client, machineIdentifier)
-		if err != nil {
-			return nil, err
-		}
-		machinesSystemIDs = append(machinesSystemIDs, machine.SystemID)
+	machines, err := client.Machines.Get(&entity.MachinesParams{})
+	if err != nil {
+		return nil, err
 	}
+	machinesSystemIDs := []string{}
+	for _, identifier := range convertToStringSlice(p.(*schema.Set).List()) {
+		found := false
+		for _, m := range machines {
+			if m.SystemID == identifier || m.Hostname == identifier || m.FQDN == identifier {
+				for i := range machinesSystemIDs {
+					if m.SystemID == machinesSystemIDs[i] {
+						return nil, fmt.Errorf("machine (%s) is referenced more than once", m.SystemID)
+					}
+				}
+				machinesSystemIDs = append(machinesSystemIDs, m.SystemID)
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("machine (%s) not found", identifier)
+		}
+	}
+
 	return machinesSystemIDs, nil
 }
 

--- a/maas/resource_maas_tag_test.go
+++ b/maas/resource_maas_tag_test.go
@@ -1,0 +1,126 @@
+package maas_test
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"terraform-provider-maas/maas/testutils"
+	"testing"
+
+	"github.com/canonical/gomaasclient/client"
+	"github.com/canonical/gomaasclient/entity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccResourceMaasTag_basic(t *testing.T) {
+
+	var tag entity.Tag
+	comment := "Test comment"
+	name := acctest.RandomWithPrefix("tf-tag-")
+	machines := os.Getenv("TF_ACC_TAG_MACHINES")
+
+	checks := []resource.TestCheckFunc{
+		testAccMaasTagCheckExists("maas_tag.test", &tag),
+		resource.TestCheckResourceAttr("maas_tag.test", "name", name),
+		resource.TestCheckResourceAttr("maas_tag.test", "comment", comment),
+		resource.TestCheckResourceAttr("maas_tag.test", "machines.#", strconv.Itoa(len(strings.Split(machines, ",")))),
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_TAG_MACHINES"}) },
+		Providers:    testutils.TestAccProviders,
+		CheckDestroy: testAccCheckMaasTagDestroy,
+		ErrorCheck:   func(err error) error { return err },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaasTag(name, comment, machines),
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+			// Test import using name
+			{
+				ResourceName: "maas_tag.test",
+				ImportState:  true,
+				ImportStateCheck: func(is []*terraform.InstanceState) error {
+					var tag *terraform.InstanceState
+					if len(is) != 1 {
+						return fmt.Errorf("expected 1 state: %#v", t)
+					}
+					tag = is[0]
+					assert.Equal(t, tag.Attributes["name"], name)
+					assert.Equal(t, tag.Attributes["comment"], comment)
+					assert.Equal(t, tag.Attributes["machines.#"], strconv.Itoa(len(strings.Split(machines, ","))))
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func testAccMaasTagCheckExists(rn string, tag *entity.Tag) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		conn := testutils.TestAccProvider.Meta().(*client.Client)
+		gotTag, err := conn.Tag.Get(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting tag: %s", err)
+		}
+
+		*tag = *gotTag
+
+		return nil
+	}
+}
+
+func testAccMaasTag(name string, comment string, machines string) string {
+	return fmt.Sprintf(`
+resource "maas_tag" "test" {
+	name        = "%s"
+	kernel_opts = "console=tty1 console=ttyS0"
+	machines    = split(",", "%s")
+	comment     = "%s"
+}
+`, name, machines, comment)
+}
+
+func testAccCheckMaasTagDestroy(s *terraform.State) error {
+	// retrieve the connection established in Provider configuration
+	conn := testutils.TestAccProvider.Meta().(*client.Client)
+
+	// loop through the resources in state, verifying each maas_tag
+	// is destroyed
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "maas_tag" {
+			continue
+		}
+
+		// Retrieve our maas_tag by referencing it's state ID for API lookup
+		response, err := conn.Tag.Get(rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.Name == rs.Primary.ID {
+				return fmt.Errorf("MAAS Tag (%s) still exists.", rs.Primary.ID)
+			}
+
+			return nil
+		}
+
+		// If the error is equivalent to 404 not found, the maas_tag is destroyed.
+		// Otherwise return the error
+		if !strings.Contains(err.Error(), "404 Not Found") {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
- Query MAAS machines only once to find system IDs of all user provided identifiers
- Check that there is no machine being added more than once with the same or different identifier
- Add simple acceptance test to confirm that `maas_tag` is working appropriately

Resolves GH: #175