### PR TITLE
Optimize getMachine function

### DIFF
--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -296,9 +296,21 @@ func waitForMachineStatus(ctx context.Context, client *client.Client, systemID s
 }
 
 func getMachine(client *client.Client, identifier string) (*entity.Machine, error) {
-	machines, err := client.Machines.Get(&entity.MachinesParams{})
+	machine, err := client.Machine.Get(identifier)
+	if err == nil {
+		return machine, nil
+	}
+	identifiers := make([]string, 1)
+	identifiers[0] = strings.Split(identifier,".")[0]
+	machines, err := client.Machines.Get(&entity.MachinesParams{Hostname: identifiers})
 	if err != nil {
 		return nil, err
+	}
+	if len(machines) < 1 {
+		machines, err = client.Machines.Get(&entity.MachinesParams{})
+		if err != nil {
+			return nil, err
+		}
 	}
 	for _, m := range machines {
 		if m.SystemID == identifier || m.Hostname == identifier || m.FQDN == identifier || m.BootInterface.MACAddress == identifier {


### PR DESCRIPTION
The getMachine is incredibly inefficient fetching a list of all machines and their components in order to look up the name or ID of just one and then doing it all over again for each component of that machine's configuration. The API provides for a Machine.Get call when using the machine ID or a params struct for Machines.Get which can specify Hostname - a commonly used element in resource calls.

Return a machine found by its ID before performing lookup on the list of all machines, then try to find a machine in the list by the hostname parameter, and finally fall back to the current list lookup dumping all data and iterating through it for a few fields.

Testing:
  Qualified on lab cluster showing reduction of 30m plan to < 3m.