### PR TITLE
refactor: Reduce testing interface name length

### DIFF
--- a/maas/resource_maas_network_interface_bond_test.go
+++ b/maas/resource_maas_network_interface_bond_test.go
@@ -67,7 +67,7 @@ resource "maas_network_interface_bond" "test" {
 func TestAccResourceMaasNetworkInterfaceBond_basic(t *testing.T) {
 
 	var networkInterfaceBond entity.NetworkInterface
-	name := acctest.RandomWithPrefix("tf-network-interface-bond")
+	name := fmt.Sprintf("tf-nic-bond-%d", acctest.RandIntRange(0, 9))
 	machine := os.Getenv("TF_ACC_NETWORK_INTERFACE_MACHINE")
 	fabric := os.Getenv("TF_ACC_FABRIC")
 

--- a/maas/resource_maas_network_interface_bridge_test.go
+++ b/maas/resource_maas_network_interface_bridge_test.go
@@ -56,7 +56,7 @@ resource "maas_network_interface_bridge" "test" {
 func TestAccResourceMaasNetworkInterfaceBridge_basic(t *testing.T) {
 
 	var networkInterfaceBridge entity.NetworkInterface
-	name := acctest.RandomWithPrefix("tf-network-interface-bridge")
+	name := fmt.Sprintf("tf-nic-br-%d", acctest.RandIntRange(0, 9))
 	machine := os.Getenv("TF_ACC_NETWORK_INTERFACE_MACHINE")
 	fabric := os.Getenv("TF_ACC_FABRIC")
 

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -44,7 +44,7 @@ resource "maas_network_interface_physical" "test" {
 func TestAccResourceMaasNetworkInterfacePhysical_basic(t *testing.T) {
 
 	var networkInterfacePhysical entity.NetworkInterface
-	name := acctest.RandomWithPrefix("tf-network-interface-physical")
+	name := fmt.Sprintf("tf-nic-eth-%d", acctest.RandIntRange(0, 9))
 	machine := os.Getenv("TF_ACC_NETWORK_INTERFACE_MACHINE")
 	fabric := os.Getenv("TF_ACC_FABRIC")
 


### PR DESCRIPTION
Addresses #261 
- Replaces `RandomWithPrefix` with a formatted string whose length is below the 15 character limit, using single digit `RandIntRange` as a suffix instead.