### PR TITLE
fix: properly unlink existing links before creating a link

### DIFF
--- a/docs/resources/network_interface_vlan.md
+++ b/docs/resources/network_interface_vlan.md
@@ -29,13 +29,14 @@ resource "maas_network_interface_vlan" "example" {
 - `fabric` (String) The identifier (name or ID) of the fabric for the new VLAN interface.
 - `machine` (String) The identifier (system ID, hostname, or FQDN) of the machine with the VLAN interface.
 - `parent` (String) Parent interface name for this VLAN interface.
+- `vlan` (Number) Database ID of the VLAN the VLAN interface is connected to.
 
 ### Optional
 
 - `accept_ra` (Boolean) Accept router advertisements. (IPv6 only).
 - `mtu` (Number) The MTU of the VLAN interface.
+- `name` (String) The name of the VLAN interface.
 - `tags` (Set of String) A set of tag names to be assigned to the VLAN interface.
-- `vlan` (Number) Database ID of the VLAN the VLAN interface is connected to.
 
 ### Read-Only
 

--- a/maas/resource_maas_network_interface_link.go
+++ b/maas/resource_maas_network_interface_link.go
@@ -189,10 +189,8 @@ func getNetworkInterfaceLinkParams(d *schema.ResourceData, subnetID int) *entity
 
 func createNetworkInterfaceLink(client *client.Client, machineSystemID string, networkInterface *entity.NetworkInterface, params *entity.NetworkInterfaceLinkParams) (*entity.NetworkInterfaceLink, error) {
 	// Clear existing links
-	// VLAN type interfaces are excluded since this action is not allowed by MAAS itself:
-	// <https://github.com/canonical/maas/blob/master/src/maasserver/models/interface.py#L2001-L2006>
-	if networkInterface.Type != "vlan" {
-		_, err := client.NetworkInterface.Disconnect(machineSystemID, networkInterface.ID)
+	for _, link := range networkInterface.Links {
+		_, err := client.NetworkInterface.UnlinkSubnet(machineSystemID, networkInterface.ID, link.ID)
 		if err != nil {
 			return nil, err
 		}

--- a/maas/resource_maas_network_interface_link_test.go
+++ b/maas/resource_maas_network_interface_link_test.go
@@ -1,0 +1,145 @@
+package maas_test
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"terraform-provider-maas/maas"
+	"terraform-provider-maas/maas/testutils"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func testAccMaasNetworkInterfaceLink(machine string, cidr string, gateway string, ip string) string {
+	return fmt.Sprintf(`
+data "maas_machine" "machine" {
+  hostname = "%s"
+}
+
+resource "maas_fabric" "test" {
+  name = "tf-fabric-0"
+}
+
+resource "maas_vlan" "default" {
+  fabric = maas_fabric.test.id
+  vid    = 1
+}
+
+resource "maas_vlan" "test" {
+  fabric = maas_fabric.test.id
+  vid    = 20
+}
+
+resource "maas_network_interface_physical" "test" {
+  machine     = data.maas_machine.machine.id
+  mac_address = "52:54:00:15:f5:3e"
+  name        = "tf0"
+  vlan        = maas_vlan.default.id
+}
+
+resource "maas_network_interface_vlan" "test" {
+  machine = data.maas_machine.machine.id
+  fabric  = maas_fabric.test.id
+  parent  = maas_network_interface_physical.test.name
+  vlan    = maas_vlan.test.id
+}
+
+resource "maas_network_interface_bridge" "test" {
+  machine = data.maas_machine.machine.id
+  parent  = maas_network_interface_vlan.test.name
+  vlan    = maas_vlan.test.id
+  name    = "tfbr"
+}
+
+resource "maas_subnet" "test" {
+  cidr       = "%s"
+  fabric     = maas_fabric.test.id
+  vlan       = maas_vlan.test.vid
+  name       = "tf_subnet"
+  gateway_ip = "%s"
+}
+
+resource "maas_network_interface_link" "test" {
+  machine           = data.maas_machine.machine.id
+  network_interface = maas_network_interface_bridge.test.id
+  subnet            = maas_subnet.test.cidr
+  mode              = "STATIC"
+  ip_address        = "%s"
+  default_gateway   = true
+}
+`, machine, cidr, gateway, ip)
+}
+
+func TestAccResourceMaasNetworkInterfaceLink_basic(t *testing.T) {
+
+	machine := os.Getenv("TF_ACC_NETWORK_INTERFACE_MACHINE")
+	cidr := "30.30.30.0/24"
+	gateway := "30.30.30.1"
+
+	checks := []resource.TestCheckFunc{
+		testAccMaasNetworkInterfaceLinkCheckExists("maas_network_interface_link.test"),
+		resource.TestCheckResourceAttr("maas_network_interface_link.test", "subnet", cidr),
+		resource.TestCheckResourceAttr("maas_network_interface_link.test", "mode", "STATIC"),
+		resource.TestCheckResourceAttr("maas_network_interface_link.test", "default_gateway", "true"),
+		resource.TestCheckResourceAttrPair("maas_network_interface_link.test", "machine", "data.maas_machine.machine", "id"),
+		resource.TestCheckResourceAttrPair("maas_network_interface_link.test", "network_interface", "maas_network_interface_bridge.test", "id"),
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
+		Providers:    testutils.TestAccProviders,
+		ErrorCheck:   func(err error) error { return err },
+		CheckDestroy: func(s *terraform.State) error { return nil },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMaasNetworkInterfaceLink(machine, cidr, gateway, "30.30.30.2"),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks, resource.TestCheckResourceAttr("maas_network_interface_link.test", "ip_address", "30.30.30.2"))...),
+			},
+			// Test update
+			{
+				Config: testAccMaasNetworkInterfaceLink(machine, cidr, gateway, "30.30.30.3"),
+				Check: resource.ComposeTestCheckFunc(
+					append(checks, resource.TestCheckResourceAttr("maas_network_interface_link.test", "ip_address", "30.30.30.3"))...),
+			},
+		},
+	})
+}
+
+func testAccMaasNetworkInterfaceLinkCheckExists(rn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		networkInterfaceID, err := strconv.Atoi(rs.Primary.Attributes["network_interface"])
+		if err != nil {
+			return err
+		}
+
+		gotNetworkInterface, err := conn.NetworkInterface.Get(rs.Primary.Attributes["machine"], networkInterfaceID)
+		if err != nil {
+			return fmt.Errorf("error getting network interface: %s", err)
+		}
+
+		for _, link := range gotNetworkInterface.Links {
+			if id == link.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("link with id: %v not found in the network interface links", id)
+	}
+}

--- a/maas/resource_maas_network_interface_vlan.go
+++ b/maas/resource_maas_network_interface_vlan.go
@@ -46,6 +46,12 @@ func resourceMaasNetworkInterfaceVlan() *schema.Resource {
 				Computed:    true,
 				Description: "The MTU of the VLAN interface.",
 			},
+			"name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "The name of the VLAN interface.",
+			},
 			"parent": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -62,8 +68,8 @@ func resourceMaasNetworkInterfaceVlan() *schema.Resource {
 			},
 			"vlan": {
 				Type:        schema.TypeInt,
-				Optional:    true,
-				Computed:    true,
+				Required:    true,
+				ForceNew:    true,
 				Description: "Database ID of the VLAN the VLAN interface is connected to.",
 			},
 		},
@@ -130,6 +136,7 @@ func resourceNetworkInterfaceVlanRead(ctx context.Context, d *schema.ResourceDat
 
 	tfState := map[string]interface{}{
 		"mtu":    networkInterface.EffectiveMTU,
+		"name":   networkInterface.Name,
 		"parent": networkInterface.Parents[0],
 		"tags":   networkInterface.Tags,
 		"vlan":   networkInterface.VLAN.ID,

--- a/maas/resource_maas_network_interface_vlan_test.go
+++ b/maas/resource_maas_network_interface_vlan_test.go
@@ -50,7 +50,7 @@ resource "maas_network_interface_vlan" "test" {
 	parent    = maas_network_interface_physical.nic1.name
 	tags      = ["tag1", "tag2"]
 	vlan      = maas_vlan.tf_vlan.id
-  }
+}
   `, fabric, machine, mtu)
 }
 


### PR DESCRIPTION
- Unlink all existing links of an interface before create a new link, instead of disconnect
- Add a new attribute to vlan interface to set a name or calculate it from MAAS
- Add acceptance tests for `maas_interface_link`
- Make `vlan` field of a vlan interface a mandatory field with force re-creation, since it was accidentally marked as optional

Resolves: #259 