### PR TITLE
fix: use unique MAC addresses for tf acc interfaces

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -171,7 +171,6 @@ Where
     Note that you may need to specify a specific machine or fabric to test against as other environment variables. Add these to your `env.sh` file before sourcing it again, if required:
     ```bash
     export TF_ACC=1
-    export TF_ACC_FABRIC=<fabric_id> # e.g. 8
     export TF_ACC_NETWORK_INTERFACE_MACHINE=<machine_id> # e.g. b68rn4
     export TF_ACC_TAG_MACHINES=<machine_id> # e.g. b68rn4
     ```

--- a/maas/data_source_maas_device_test.go
+++ b/maas/data_source_maas_device_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceMaasDevice_basic(t *testing.T) {
 	domain := acctest.RandomWithPrefix("tf-domain-")
 	hostname := acctest.RandomWithPrefix("tf-device-")
 	zone := "default"
-	mac_address := "12:23:45:67:89:fa"
+	mac_address := testutils.RandomMAC()
 
 	checks := []resource.TestCheckFunc{
 		testAccMaasDeviceCheckExists("maas_device.test", &device),

--- a/maas/resource_maas_device_test.go
+++ b/maas/resource_maas_device_test.go
@@ -20,7 +20,7 @@ func TestAccResourceMaasDevice_basic(t *testing.T) {
 	domain := acctest.RandomWithPrefix("tf-domain-")
 	hostname := acctest.RandomWithPrefix("tf-device-")
 	zone := "default"
-	mac_address := "12:23:45:67:89:de"
+	mac_address := testutils.RandomMAC()
 
 	checks := []resource.TestCheckFunc{
 		testAccMaasDeviceCheckExists("maas_device.test", &device),

--- a/maas/testutils/helpers.go
+++ b/maas/testutils/helpers.go
@@ -1,0 +1,21 @@
+package testutils
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// RandomMAC generates a random locally administered MAC address.
+func RandomMAC() string {
+	mac := make([]byte, 6)
+
+	// Fill the slice with random bytes
+	rand.Read(mac)
+
+	// Ensure the MAC address is valid:
+	// - Bit 0 of the first byte is cleared (ensuring it's a unicast address)
+	// - Bit 1 of the first byte is set (marking it as locally administered)
+	mac[0] = (mac[0] & 0xFE) | 0x02
+
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
+}


### PR DESCRIPTION
## Description of changes

Stop using the same MAC address for interface creation during acceptance tests. If `maas_interface_bridge` and `maas_interface_link` tests run on parallel against the same machine, using the same MAC address for creating interfaces can cause issues. Being more specific, the two tests can compete for the same interface and the delete part of the one can delete the interface of the other.

Changes include:

- Stop expecting a pre-created fabric for the test. Instead create different fabrics per interface acceptance test
- Introduce a random MAC address generator to produce random MAC addresses for the needs of the tests
- Remove references to `TF_ACC_FABRIC` since it is not needed anymore

## Issue or ticket link (if applicable)

N/A

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type(scope): title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
