### PR TITLE
fix: 195 dns record removal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module terraform-provider-maas
 
-go 1.22.7
+go 1.23
+
+toolchain go1.23.6
 
 require (
 	github.com/bflad/tfproviderlint v0.31.0
@@ -40,6 +42,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
+	github.com/hashicorp/go-set/v3 v3.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/hashicorp/go-plugin v1.6.2 h1:zdGAEd0V1lCaU0u+MxWQhtSDQmahpkwOun8U8Ei
 github.com/hashicorp/go-plugin v1.6.2/go.mod h1:CkgLQ5CZqNmdL9U9JzM532t8ZiYQ35+pj3b1FD37R0Q=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=
 github.com/hashicorp/go-retryablehttp v0.7.7/go.mod h1:pkQpWZeYWskR+D1tR2O5OcBFOxfA7DoAO6xtkuQnHTk=
+github.com/hashicorp/go-set/v3 v3.0.0 h1:CaJBQvQCOWoftrBcDt7Nwgo0kdpmrKxar/x2o6pV9JA=
+github.com/hashicorp/go-set/v3 v3.0.0/go.mod h1:IEghM2MpE5IaNvL+D7X480dfNtxjRXZ6VMpK3C8s2ok=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/Co8=

--- a/maas/resource_maas_dns_record.go
+++ b/maas/resource_maas_dns_record.go
@@ -185,18 +185,18 @@ func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	if d.Get("type").(string) == "A/AAAA" {
-		dnsResource, err := client.DNSResource.Get(id)
-		if err != nil {
-			return diag.FromErr(err)
-		}
+		// dnsResource, err := client.DNSResource.Get(id)
+		// if err != nil {
+		// 	return diag.FromErr(err)
+		// }
 		if err := client.DNSResource.Delete(id); err != nil {
 			return diag.FromErr(err)
-		}
-		for _, ipAddress := range dnsResource.IPAddresses {
-			if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil {
-				return diag.FromErr(err)
-			}
-		}
+		}	
+		// for _, ipAddress := range dnsResource.IPAddresses {
+		// 	if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil {
+		// 		return diag.FromErr(err)
+		// 	}
+		// }
 	} else {
 		if err := client.DNSResourceRecord.Delete(id); err != nil {
 			return diag.FromErr(err)

--- a/maas/resource_maas_dns_record.go
+++ b/maas/resource_maas_dns_record.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -191,11 +192,9 @@ func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		}
 		if err := client.DNSResource.Delete(id); err != nil {
 			return diag.FromErr(err)
-		}	
-		for _, ipAddress := range dnsResource.IPAddresses {
-			if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil {
-				return diag.FromErr(err)
-			}
+		}
+		if err := releaseDNSResourceIPAddresses(client, dnsResource, id); err != nil {
+			return diag.FromErr(err)
 		}
 	} else {
 		if err := client.DNSResourceRecord.Delete(id); err != nil {
@@ -203,6 +202,36 @@ func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		}
 	}
 
+	return nil
+}
+
+// Release all IP addresses of a DNS resource, but only if it is not used by other DNS resources.
+// NOTE: exactly why this is required here and not in MAAS itself is not clear. 
+func releaseDNSResourceIPAddresses(client *client.Client, dnsResource *entity.DNSResource, dnsID int) error {
+	allDNSResources, err := client.DNSResources.Get(&entity.DNSResourcesParams{})
+	if err != nil {
+		return err
+	}
+	allOtherDNSResourcesIPAddresses := set.New[string](0)
+	for _, r := range allDNSResources {
+		if r.ID == dnsID {
+			continue
+		}
+		for _, ipAddress := range r.IPAddresses {
+			allOtherDNSResourcesIPAddresses.Insert(ipAddress.IP.String())
+		}
+	}
+	for _, ipAddress := range dnsResource.IPAddresses {
+		if allOtherDNSResourcesIPAddresses.Contains(ipAddress.IP.String()) {
+			continue
+		}
+		// Release the IP address if it is not used by another DNS resource. 
+		// Terraform removes resources in parallel, so if it's already been deleted 
+		// by another resource pointing to the same IP being removed, ignore it.
+		if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil && !strings.Contains(err.Error(), "does not exist") {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/maas/resource_maas_dns_record.go
+++ b/maas/resource_maas_dns_record.go
@@ -206,7 +206,7 @@ func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 }
 
 // Release all IP addresses of a DNS resource, but only if it is not used by other DNS resources.
-// NOTE: exactly why this is required here and not in MAAS itself is not clear. 
+// NOTE: exactly why this is required here and not in MAAS itself is not clear.
 func releaseDNSResourceIPAddresses(client *client.Client, dnsResource *entity.DNSResource, dnsID int) error {
 	allDNSResources, err := client.DNSResources.Get(&entity.DNSResourcesParams{})
 	if err != nil {
@@ -225,8 +225,8 @@ func releaseDNSResourceIPAddresses(client *client.Client, dnsResource *entity.DN
 		if allOtherDNSResourcesIPAddresses.Contains(ipAddress.IP.String()) {
 			continue
 		}
-		// Release the IP address if it is not used by another DNS resource. 
-		// Terraform removes resources in parallel, so if it's already been deleted 
+		// Release the IP address if it is not used by another DNS resource.
+		// Terraform removes resources in parallel, so if it's already been deleted
 		// by another resource pointing to the same IP being removed, ignore it.
 		if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil && !strings.Contains(err.Error(), "does not exist") {
 			return err

--- a/maas/resource_maas_dns_record.go
+++ b/maas/resource_maas_dns_record.go
@@ -185,18 +185,18 @@ func resourceDnsRecordDelete(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	if d.Get("type").(string) == "A/AAAA" {
-		// dnsResource, err := client.DNSResource.Get(id)
-		// if err != nil {
-		// 	return diag.FromErr(err)
-		// }
+		dnsResource, err := client.DNSResource.Get(id)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 		if err := client.DNSResource.Delete(id); err != nil {
 			return diag.FromErr(err)
 		}	
-		// for _, ipAddress := range dnsResource.IPAddresses {
-		// 	if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil {
-		// 		return diag.FromErr(err)
-		// 	}
-		// }
+		for _, ipAddress := range dnsResource.IPAddresses {
+			if err := client.IPAddresses.Release(&entity.IPAddressesParams{IP: ipAddress.IP.String()}); err != nil {
+				return diag.FromErr(err)
+			}
+		}
 	} else {
 		if err := client.DNSResourceRecord.Delete(id); err != nil {
 			return diag.FromErr(err)

--- a/maas/resource_maas_dns_record_test.go
+++ b/maas/resource_maas_dns_record_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 	var dnsRecord entity.DNSResource
-	randomString := acctest.RandomWithPrefix("tf-dns-record-")
+	recordBaseName := acctest.RandomWithPrefix("tf-dns-record-")
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
@@ -26,16 +26,17 @@ func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 		ErrorCheck:   func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
-				Config: getDNSRecordConfig(randomString),
+				Config: getDNSRecordConfig(recordBaseName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccMAASDNSRecordCheckExists("maas_dns_record.test_aaaa_1", &dnsRecord),
+					resource.TestCheckResourceAttr("maas_dns_record.test_aaaa_1", "name", recordBaseName+"-1"),
 				),
 			},
 		},
 	})
 }
 
-func getDNSRecordConfig(randomString string) string {
+func getDNSRecordConfig(recordBaseName string) string {
 	return fmt.Sprintf(`
 	resource "maas_dns_record" "test_aaaa_1" {
 		name = "%s-1"
@@ -49,7 +50,7 @@ func getDNSRecordConfig(randomString string) string {
 		data = "8.8.8.8"
 		domain = "maas"
 	}
-	`, randomString, randomString)
+	`, recordBaseName, recordBaseName)
 }
 
 // Check if the DNS record specified actually exists in MAAS

--- a/maas/resource_maas_dns_record_test.go
+++ b/maas/resource_maas_dns_record_test.go
@@ -9,51 +9,103 @@ import (
 	"terraform-provider-maas/maas"
 	"terraform-provider-maas/maas/testutils"
 
+	"github.com/canonical/gomaasclient/client"
 	"github.com/canonical/gomaasclient/entity"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+
+
 func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 	var dnsRecord entity.DNSResource
-	recordBaseName := acctest.RandomWithPrefix("tf-dns-record-")
+	recordName := acctest.RandomWithPrefix("tf-dns-record-")
+	const recordName1 = "maas_dns_record.test"
+	const TEST_IP_ADDRESS = "8.8.8.8"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccMAASDNSRecordCheckDestroy,
+		CheckDestroy: testAccMAASDNSRecordCheckDestroy(TEST_IP_ADDRESS),
 		ErrorCheck:   func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
-				Config: getDNSRecordConfig(recordBaseName),
+				Config: getDNSRecordConfigBasic(recordName, "A/AAAA", TEST_IP_ADDRESS, "maas"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccMAASDNSRecordCheckExists("maas_dns_record.test_aaaa_1", &dnsRecord),
-					resource.TestCheckResourceAttr("maas_dns_record.test_aaaa_1", "name", recordBaseName+"-1"),
+					testAccMAASDNSRecordCheckExists(recordName1, &dnsRecord),
+					resource.TestCheckResourceAttr(recordName1, "name", recordName),
+					resource.TestCheckResourceAttr(recordName1, "type", "A/AAAA"),
+					resource.TestCheckResourceAttr(recordName1, "data", TEST_IP_ADDRESS),
+					resource.TestCheckResourceAttr(recordName1, "domain", "maas"),
 				),
 			},
 		},
 	})
 }
 
-func getDNSRecordConfig(recordBaseName string) string {
-	return fmt.Sprintf(`
-	resource "maas_dns_record" "test_aaaa_1" {
-		name = "%s-1"
-		type = "A/AAAA"
-		data = "8.8.8.8"
-		domain = "maas"
-	}
-	resource "maas_dns_record" "test_aaaa_2" {
-		name = "%s-2"
-		type = "A/AAAA"
-		data = "8.8.8.8"
-		domain = "maas"
-	}
-	`, recordBaseName, recordBaseName)
+// Test that two DNS records with the same IP address can be created and destroyed.
+func TestAccResourceMAASDNSRecord_same_ip_address(t *testing.T) {
+	var dnsRecord entity.DNSResource
+	recordBaseName := acctest.RandomWithPrefix("tf-dns-record-")
+	const recordName1 = "maas_dns_record.test_aaaa_1"
+	const recordName2 = "maas_dns_record.test_aaaa_2"
+	const TEST_IP_ADDRESS_2 = "8.8.8.9"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.TestAccProviders,
+		CheckDestroy: testAccMAASDNSRecordCheckDestroy(TEST_IP_ADDRESS_2),
+		ErrorCheck:   func(err error) error { return err },
+		Steps: []resource.TestStep{
+			{
+				Config: getDNSRecordConfigSameIPA_AAAA(recordBaseName, TEST_IP_ADDRESS_2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMAASDNSRecordCheckExists(recordName1, &dnsRecord),
+					testAccMAASDNSRecordCheckExists(recordName2, &dnsRecord),
+					// resource.TestCheckResourceAttr(recordName1, "name", recordBaseName+"-1"),
+					// resource.TestCheckResourceAttr(recordName2, "name", recordBaseName+"-2"),
+					resource.TestCheckResourceAttr(recordName1, "type", "A/AAAA"),
+					resource.TestCheckResourceAttr(recordName2, "type", "A/AAAA"),
+					resource.TestCheckResourceAttr(recordName1, "data", TEST_IP_ADDRESS_2),
+					resource.TestCheckResourceAttr(recordName2, "data", TEST_IP_ADDRESS_2),
+					resource.TestCheckResourceAttr(recordName1, "domain", "maas"),
+					resource.TestCheckResourceAttr(recordName2, "domain", "maas"),
+				),
+			},
+		},
+	})
 }
 
-// Check if the DNS record specified actually exists in MAAS
+func getDNSRecordConfigSameIPA_AAAA(recordBaseName string, ipAddress string) string {
+	return fmt.Sprintf(`
+	resource "maas_dns_record" "test_aaaa_1" {
+	  name   = "%s-1"
+	  type   = "A/AAAA"
+	  data   = %q
+	  domain = "maas"
+	}
+	resource "maas_dns_record" "test_aaaa_2" {
+	  name   = "%s-2"
+	  type   = "A/AAAA"
+	  data   = %q
+	  domain = "maas"
+	}
+	`, recordBaseName, ipAddress, recordBaseName, ipAddress)
+}
+
+func getDNSRecordConfigBasic(name string, recordType string, data string, domain string) string {
+	return fmt.Sprintf(`
+	resource "maas_dns_record" "test" {
+	  name   = "%s"
+	  type   = "%s"
+	  data   = "%s"
+	  domain = "%s"
+	}
+	`, name, recordType, data, domain)
+}
+
+// Check if the DNS record specified exists in MAAS. If not, return an error.
 func testAccMAASDNSRecordCheckExists(rn string, dnsRecord *entity.DNSResource) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Check if it exists in state
@@ -82,34 +134,65 @@ func testAccMAASDNSRecordCheckExists(rn string, dnsRecord *entity.DNSResource) r
 	}	
 }	
 
-func testAccMAASDNSRecordCheckDestroy(s *terraform.State) error {
-	conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
-	for _, rs := range s.RootModule().Resources {
-		// Skip if the resource is not a dns record
-		if rs.Type != "maas_dns_record" {
-			continue
-		}
-		// Convert the resource ID to an integer
-		id, err := strconv.Atoi(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
 
-		// Check if the dns record exists
-		response, err := conn.DNSResource.Get(id)
-		if err == nil {
-			if response != nil && response.ID == id {
-				return fmt.Errorf("dns record still exists: %s", rs.Primary.ID)
+func testAccMAASDNSRecordCheckDestroy(ipAddress string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+		for _, rs := range s.RootModule().Resources {
+			// Skip if the resource is not a dns record
+			if rs.Type != "maas_dns_record" {
+				continue
+			}
+			// Convert the resource ID to an integer
+			id, err := strconv.Atoi(rs.Primary.ID)
+			if err != nil {
+				return err
+			}
+
+			// Check if the dns record exists
+			response, err := conn.DNSResource.Get(id)
+			if err == nil {
+				if response != nil && response.ID == id {
+					return fmt.Errorf("dns record still exists: %s", rs.Primary.ID)
+				}
+			}
+
+			// If the error is equivalent to 404 not found, the dns record is destroyed.
+			// Otherwise return the error
+			if !strings.Contains(err.Error(), "404 Not Found") {	
+				return err
 			}
 		}
 
-		// If the error is equivalent to 404 not found, the dns record is destroyed.
-		// Otherwise return the error
-		if !strings.Contains(err.Error(), "404 Not Found") {	
-			return err
+		// Check if the IP address is released
+		ipAllocated, err := isIPAddressAllocated(conn, ipAddress)
+		if err != nil {
+			return fmt.Errorf("error checking if ip address is released: %s", err)
 		}
-
+		if ipAllocated {
+			return fmt.Errorf("ip address is not released: %s with error: %s", ipAddress, err	)
+		}
+		return nil
 	}
-	return nil
 }
 
+// Check if a particular IP address is allocated in MAAS
+func isIPAddressAllocated(conn *client.Client, ipAddress string) (bool, error) {
+	params := &entity.IPAddressesParams{IP: ipAddress}
+	allIPAddresses, err := conn.IPAddresses.Get(params)
+	if err != nil {
+		if strings.Contains(err.Error(), "does not exist") {
+			// The IP address is already allocated
+			return false, nil
+		}
+		// The IP address could be allocated, return the error
+		return false, err 
+	}
+
+	for _, ip := range allIPAddresses {
+		if ip.IP.String() == ipAddress {
+			return true, fmt.Errorf("ip address is allocated")
+		}
+	}
+	return false, nil
+}

--- a/maas/resource_maas_dns_record_test.go
+++ b/maas/resource_maas_dns_record_test.go
@@ -3,6 +3,7 @@ package maas_test
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"terraform-provider-maas/maas"
@@ -21,7 +22,7 @@ func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },
 		Providers:    testutils.TestAccProviders,
-		CheckDestroy: func(s *terraform.State) error { return nil },
+		CheckDestroy: testAccMAASDNSRecordCheckDestroy,
 		ErrorCheck:   func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
@@ -32,35 +33,6 @@ func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-// Check if the DNS record specified actually exists in MAAS
-func testAccMAASDNSRecordCheckExists(rn string, dnsRecord *entity.DNSResource) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// Check if it exists in state
-		rs, ok := s.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("resource id not set")
-		}
-
-		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
-		id, err := strconv.Atoi(rs.Primary.ID)
-		if err != nil {
-			return err
-		}
-		gotDNSRecord, err := conn.DNSResource.Get(id)
-		if err != nil {
-			return fmt.Errorf("error getting dns record: %s", err)
-		}
-
-		*dnsRecord = *gotDNSRecord
-
-		return nil
-	}
 }
 
 func getDNSRecordConfig(randomString string) string {
@@ -78,5 +50,65 @@ func getDNSRecordConfig(randomString string) string {
 		domain = "maas"
 	}
 	`, randomString, randomString)
+}
+
+// Check if the DNS record specified actually exists in MAAS
+func testAccMAASDNSRecordCheckExists(rn string, dnsRecord *entity.DNSResource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Check if it exists in state
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}	
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}	
+
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}	
+		gotDNSRecord, err := conn.DNSResource.Get(id)
+		if err != nil {
+			return fmt.Errorf("error getting dns record: %s", err)
+		}	
+
+		*dnsRecord = *gotDNSRecord
+
+		return nil
+	}	
+}	
+
+func testAccMAASDNSRecordCheckDestroy(s *terraform.State) error {
+	conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+	for _, rs := range s.RootModule().Resources {
+		// Skip if the resource is not a dns record
+		if rs.Type != "maas_dns_record" {
+			continue
+		}
+		// Convert the resource ID to an integer
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		// Check if the dns record exists
+		response, err := conn.DNSResource.Get(id)
+		if err == nil {
+			if response != nil && response.ID == id {
+				return fmt.Errorf("dns record still exists: %s", rs.Primary.ID)
+			}
+		}
+
+		// If the error is equivalent to 404 not found, the dns record is destroyed.
+		// Otherwise return the error
+		if !strings.Contains(err.Error(), "404 Not Found") {	
+			return err
+		}
+
+	}
+	return nil
 }
 

--- a/maas/resource_maas_dns_record_test.go
+++ b/maas/resource_maas_dns_record_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-
-
 func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 	var dnsRecord entity.DNSResource
 	recordName := acctest.RandomWithPrefix("tf-dns-record-")
@@ -112,28 +110,27 @@ func testAccMAASDNSRecordCheckExists(rn string, dnsRecord *entity.DNSResource) r
 		rs, ok := s.RootModule().Resources[rn]
 		if !ok {
 			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
-		}	
+		}
 
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set")
-		}	
+		}
 
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
 		id, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
 			return err
-		}	
+		}
 		gotDNSRecord, err := conn.DNSResource.Get(id)
 		if err != nil {
 			return fmt.Errorf("error getting dns record: %s", err)
-		}	
+		}
 
 		*dnsRecord = *gotDNSRecord
 
 		return nil
-	}	
-}	
-
+	}
+}
 
 func testAccMAASDNSRecordCheckDestroy(ipAddress string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -159,7 +156,7 @@ func testAccMAASDNSRecordCheckDestroy(ipAddress string) resource.TestCheckFunc {
 
 			// If the error is equivalent to 404 not found, the dns record is destroyed.
 			// Otherwise return the error
-			if !strings.Contains(err.Error(), "404 Not Found") {	
+			if !strings.Contains(err.Error(), "404 Not Found") {
 				return err
 			}
 		}
@@ -170,7 +167,7 @@ func testAccMAASDNSRecordCheckDestroy(ipAddress string) resource.TestCheckFunc {
 			return fmt.Errorf("error checking if ip address is released: %s", err)
 		}
 		if ipAllocated {
-			return fmt.Errorf("ip address is not released: %s with error: %s", ipAddress, err	)
+			return fmt.Errorf("ip address is not released: %s with error: %s", ipAddress, err)
 		}
 		return nil
 	}
@@ -186,7 +183,7 @@ func isIPAddressAllocated(conn *client.Client, ipAddress string) (bool, error) {
 			return false, nil
 		}
 		// The IP address could be allocated, return the error
-		return false, err 
+		return false, err
 	}
 
 	for _, ip := range allIPAddresses {

--- a/maas/resource_maas_dns_record_test.go
+++ b/maas/resource_maas_dns_record_test.go
@@ -1,0 +1,82 @@
+package maas_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"terraform-provider-maas/maas"
+	"terraform-provider-maas/maas/testutils"
+
+	"github.com/canonical/gomaasclient/entity"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
+	var dnsRecord entity.DNSResource
+	randomString := acctest.RandomWithPrefix("tf-dns-record-")
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.TestAccProviders,
+		CheckDestroy: func(s *terraform.State) error { return nil },
+		ErrorCheck:   func(err error) error { return err },
+		Steps: []resource.TestStep{
+			{
+				Config: getDNSRecordConfig(randomString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccMAASDNSRecordCheckExists("maas_dns_record.test_aaaa_1", &dnsRecord),
+				),
+			},
+		},
+	})
+}
+
+// Check if the DNS record specified actually exists in MAAS
+func testAccMAASDNSRecordCheckExists(rn string, dnsRecord *entity.DNSResource) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Check if it exists in state
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+		id, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		gotDNSRecord, err := conn.DNSResource.Get(id)
+		if err != nil {
+			return fmt.Errorf("error getting dns record: %s", err)
+		}
+
+		*dnsRecord = *gotDNSRecord
+
+		return nil
+	}
+}
+
+func getDNSRecordConfig(randomString string) string {
+	return fmt.Sprintf(`
+	resource "maas_dns_record" "test_aaaa_1" {
+		name = "%s-1"
+		type = "A/AAAA"
+		data = "8.8.8.8"
+		domain = "maas"
+	}
+	resource "maas_dns_record" "test_aaaa_2" {
+		name = "%s-2"
+		type = "A/AAAA"
+		data = "8.8.8.8"
+		domain = "maas"
+	}
+	`, randomString, randomString)
+}
+


### PR DESCRIPTION
## Description of changes

Fixes the issue of accidental deletion of both DNS resources that share a common IP address when one is deleted. This also fixes an error caused by a race condition when destroying both resources. 

## Issue or ticket link (if applicable)

Resolves https://github.com/canonical/terraform-provider-maas/issues/195
Supersedes https://github.com/canonical/terraform-provider-maas/pull/196

## Checklist

- [ ] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type(scope): title`
- [ ] I have written a description of the changes in the PR that is clear and concise.
- [ ] I have updated the documentation to reflect the changes.
- [ ] I have added or updated the tests to reflect the changes.
- [ ] I have run the unit tests and they pass.
- [ ] I have run the acceptance tests and they pass.
