### PR TITLE
fix: avoid subnet cidr collisions

### DIFF
--- a/maas/resource_maas_device_test.go
+++ b/maas/resource_maas_device_test.go
@@ -80,10 +80,10 @@ func TestAccResourceMaasDevice_update(t *testing.T) {
 	mac_address := testutils.RandomMAC()
 	mac_address2 := testutils.RandomMAC()
 	fabricName := acctest.RandomWithPrefix("tf-fabric")
-	subnetCIDR := "10.77.77.0/24"
+	subnetCIDR := testutils.GenerateRandomCidr()
 	subnetName := acctest.RandomWithPrefix("tf-subnet")
-	subnetGatewayIP := "10.77.77.1"
-	linkIPAddress := "10.77.77.42"
+	subnetGatewayIP := testutils.GetNetworkPrefixFromCidr(subnetCIDR) + ".1"
+	linkIPAddress := testutils.GetNetworkPrefixFromCidr(subnetCIDR) + ".42"
 	checks := []resource.TestCheckFunc{
 		testAccMaasDeviceCheckExists("maas_device.test", &device),
 		resource.TestCheckResourceAttr("maas_device.test", "hostname", deviceHostname),

--- a/maas/resource_maas_network_interface_link_test.go
+++ b/maas/resource_maas_network_interface_link_test.go
@@ -107,9 +107,9 @@ resource "maas_network_interface_link" "first" {
 func TestAccResourceMaasNetworkInterfaceLink_device(t *testing.T) {
 	macAddress := testutils.RandomMAC()
 	randomName := acctest.RandomWithPrefix("tf-test")
-	cidr := "10.77.77.0/24"
-	gateway := "10.77.77.1"
-	ipAddress := "10.77.77.42"
+	cidr := testutils.GenerateRandomCidr()
+	gateway := testutils.GetNetworkPrefixFromCidr(cidr) + ".1"
+	ipAddress := testutils.GetNetworkPrefixFromCidr(cidr) + ".42"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:     func() { testutils.PreCheck(t, nil) },

--- a/maas/resource_maas_subnet_ip_range_test.go
+++ b/maas/resource_maas_subnet_ip_range_test.go
@@ -21,10 +21,12 @@ func TestAccResourceMaasSubnetIPRange_basic(t *testing.T) {
 	ipRangeAttrName := "maas_subnet_ip_range.test_ip_range"
 	range_type := "reserved"
 	comment := "test-comment"
-	ipStart := "10.88.88.1"
-	ipEnd := "10.88.88.50"
-	ipStartMod := "10.88.88.2"
-	ipEndMod := "10.88.88.49"
+	cidr := testutils.GenerateRandomCidr()
+	gateway := testutils.GetNetworkPrefixFromCidr(cidr) + ".1"
+	ipStart := testutils.GetNetworkPrefixFromCidr(cidr) + ".2"
+	ipEnd := testutils.GetNetworkPrefixFromCidr(cidr) + ".50"
+	ipStartMod := testutils.GetNetworkPrefixFromCidr(cidr) + ".2"
+	ipEndMod := testutils.GetNetworkPrefixFromCidr(cidr) + ".49"
 	commentMod := "a-different-comment"
 
 	// Check functions
@@ -45,7 +47,9 @@ func TestAccResourceMaasSubnetIPRange_basic(t *testing.T) {
 			// Test creation
 			{
 				Config: testAccSubnetIPRangeExampleResource(
+					cidr,
 					subnet_name,
+					gateway,
 					range_type,
 					comment,
 					ipStart,
@@ -129,7 +133,9 @@ func testAccMAASSubnetIPRangeCheckExists(rn string, ipRange *entity.IPRange) res
 // An example resource configuration for a subnet IP range.
 // Note that a subnet is required to create an IP range.
 func testAccSubnetIPRangeExampleResource(
+	cidr string,
 	name_subnet string,
+	gateway string,
 	range_type string,
 	comment string,
 	start_ip string,
@@ -138,20 +144,20 @@ func testAccSubnetIPRangeExampleResource(
 	// A subnet is required to create an IP range
 	return fmt.Sprintf(`
 		resource "maas_subnet" "test_subnet" {
-		  cidr        = "10.88.88.0/26"
-		  name        = "%s"
-		  gateway_ip  = "10.88.88.1"
+		  cidr        = %q
+		  name        = %q
+		  gateway_ip  = %q
 		  dns_servers = ["8.8.8.8"]
 		}
 
 		resource "maas_subnet_ip_range" "test_ip_range" {
 		  subnet   = maas_subnet.test_subnet.id
-		  type     = "%s"
-		  start_ip = "%s"
-		  end_ip   = "%s"
-		  comment  = "%s"
+		  type     = %q
+		  start_ip = %q
+		  end_ip   = %q
+		  comment  = %q
 		}
-	`, name_subnet, range_type, start_ip, end_ip, comment)
+	`, cidr, name_subnet, gateway, range_type, start_ip, end_ip, comment)
 }
 
 func testAccCheckMAASSubnetIPRangeDestroy(s *terraform.State) error {

--- a/maas/testutils/helpers.go
+++ b/maas/testutils/helpers.go
@@ -1,11 +1,11 @@
 package testutils
 
 import (
-	"math/rand"
 	"fmt"
-	"time"
 	"log"
+	"math/rand"
 	"strings"
+	"time"
 )
 
 // RandomMAC generates a random locally administered MAC address.
@@ -33,8 +33,8 @@ func GenerateRandomCidr() string {
 	// Arbitrary minIpRange to ensure the CIDR generated doesn't conflict with any existing MAAS networks
 	minIpRange := 50
 	maxIpRange := 255
-	
-	cidr := fmt.Sprintf("10.%d.%d.0/24", generateRandomNumberInRange(minIpRange, maxIpRange) , generateRandomNumberInRange(minIpRange, maxIpRange))
+
+	cidr := fmt.Sprintf("10.%d.%d.0/24", generateRandomNumberInRange(minIpRange, maxIpRange), generateRandomNumberInRange(minIpRange, maxIpRange))
 	return cidr
 }
 

--- a/maas/testutils/helpers.go
+++ b/maas/testutils/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 	"log"
+	"strings"
 )
 
 // RandomMAC generates a random locally administered MAC address.
@@ -35,6 +36,11 @@ func GenerateRandomCidr() string {
 	
 	cidr := fmt.Sprintf("10.%d.%d.0/24", generateRandomNumberInRange(minIpRange, maxIpRange) , generateRandomNumberInRange(minIpRange, maxIpRange))
 	return cidr
+}
+
+// Returns the network prefix from a CIDR. For example 10.77.77.0/24 would return 10.77.77
+func GetNetworkPrefixFromCidr(cidr string) string {
+	return strings.Join(strings.Split(cidr, ".")[:3], ".")
 }
 
 func generateRandomNumberInRange(min int, max int) int {

--- a/maas/testutils/helpers.go
+++ b/maas/testutils/helpers.go
@@ -1,8 +1,10 @@
 package testutils
 
 import (
-	"crypto/rand"
+	"math/rand"
 	"fmt"
+	"time"
+	"log"
 )
 
 // RandomMAC generates a random locally administered MAC address.
@@ -18,4 +20,23 @@ func RandomMAC() string {
 	mac[0] = (mac[0] & 0xFE) | 0x02
 
 	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5])
+}
+
+// Generate a random CIDR of the form 10.x.y.0/24, where x and y are random numbers in the usable range of 50 to 255
+func GenerateRandomCidr() string {
+	// Create and log a seed if required for test reproducibility
+	seed := time.Now().UnixNano()
+	rand.New(rand.NewSource(seed))
+	log.Printf("Seed used for random CIDR: %d", seed)
+
+	// Arbitrary minIpRange to ensure the CIDR generated doesn't conflict with any existing MAAS networks
+	minIpRange := 50
+	maxIpRange := 255
+	
+	cidr := fmt.Sprintf("10.%d.%d.0/24", generateRandomNumberInRange(minIpRange, maxIpRange) , generateRandomNumberInRange(minIpRange, maxIpRange))
+	return cidr
+}
+
+func generateRandomNumberInRange(min int, max int) int {
+	return rand.Intn(max-min) + min
 }

--- a/maas/testutils/helpers_test.go
+++ b/maas/testutils/helpers_test.go
@@ -1,0 +1,49 @@
+package testutils
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestGenerateRandomNumberInRange(t *testing.T) {
+	min := 0
+	max := 5
+	iterations := 200
+
+	for i := 0; i < iterations; i++ {
+		result := generateRandomNumberInRange(min, max)
+		if result < min || result > max {
+			t.Errorf("Generated number %d is less than minimum %d or greater than maximum %d", result, min, max)
+		}
+		
+	}
+}
+
+func TestGenerateRandomCidr(t *testing.T) {
+	cidr := GenerateRandomCidr()
+
+	parts := strings.Split(cidr, ".")
+	if len(parts) != 4 {
+		t.Errorf("CIDR should have 4 parts, got %d parts: %s", len(parts), cidr)
+	}
+	// Check the first and last octets
+	if parts[0] != "10" {
+		t.Errorf("First octet should be 10, got %s", parts[0])
+	}
+	lastPart := parts[3]
+	if lastPart != "0/24" {
+		t.Errorf("CIDR should end with 0/24, got %s", lastPart)
+	}
+	// Check middle octets are within the range of 0 to 255
+	for i := 1; i <= 2; i++ {
+		octet, err := strconv.Atoi(parts[i])
+		if err != nil {
+			t.Errorf("Failed to convert octet to integer: %v", err)
+		}
+		if octet < 50 || octet > 255 {
+			t.Errorf("Octet %d should be between 50 and 255, got %d", i, octet)
+		}
+	}
+
+}

--- a/maas/testutils/helpers_test.go
+++ b/maas/testutils/helpers_test.go
@@ -20,6 +20,23 @@ func TestGenerateRandomNumberInRange(t *testing.T) {
 	}
 }
 
+func TestGetNetworkPrefixFromCidr(t *testing.T) {
+	tests := []struct {
+		input string
+		output string
+	} {
+		{"192.168.1.0/24", "192.168.1"},
+        {"10.0.0.0/8", "10.0.0"},
+	}
+
+	for _, test := range tests {
+		prefix := GetNetworkPrefixFromCidr(test.input)
+		if prefix != test.output {
+			t.Errorf("Prefix should be %s, got %s", test.output, prefix)
+		}
+	}
+}
+
 func TestGenerateRandomCidr(t *testing.T) {
 	cidr := GenerateRandomCidr()
 

--- a/maas/testutils/helpers_test.go
+++ b/maas/testutils/helpers_test.go
@@ -16,17 +16,17 @@ func TestGenerateRandomNumberInRange(t *testing.T) {
 		if result < min || result > max {
 			t.Errorf("Generated number %d is less than minimum %d or greater than maximum %d", result, min, max)
 		}
-		
+
 	}
 }
 
 func TestGetNetworkPrefixFromCidr(t *testing.T) {
 	tests := []struct {
-		input string
+		input  string
 		output string
-	} {
+	}{
 		{"192.168.1.0/24", "192.168.1"},
-        {"10.0.0.0/8", "10.0.0"},
+		{"10.0.0.0/8", "10.0.0"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Description of changes

Add generating a random CIDR test function, to highly reduce the likelyhood of CIDR collisions during test which were the cause of some flakey tests.

## Issue or ticket link (if applicable)

CI run with CIDR error: http://maas-ci.internal:8080/view/terraform/job/gh-maas-terraform-provider-tester/419/console

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type(scope): title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
