### PR TITLE
chore(deps): bump github.com/canonical/gomaasclient from 0.8.0 to 0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.1
 
 require (
 	github.com/bflad/tfproviderlint v0.31.0
-	github.com/canonical/gomaasclient v0.8.0
+	github.com/canonical/gomaasclient v0.9.0
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-set/v2 v2.1.0
 	github.com/hashicorp/terraform-plugin-docs v0.21.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/bmatcuk/doublestar/v4 v4.8.1 h1:54Bopc5c2cAvhLRAzqOGCYHYyhcDHsFF4wWIR
 github.com/bmatcuk/doublestar/v4 v4.8.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.4.0 h1:LbFKd2XowZvQ/kajzguUp2DC9UEIQhIq77fZZlaQsNA=
 github.com/bufbuild/protocompile v0.4.0/go.mod h1:3v93+mbWn/v3xzN+31nwkJfrEpAUwp+BagBSZWx+TP8=
-github.com/canonical/gomaasclient v0.8.0 h1:8lcMNhyW32q1+5X/mc8+pZBmqHdtof4A8atTP5Ag1eA=
-github.com/canonical/gomaasclient v0.8.0/go.mod h1:VS99xiJeSCUCqd574qNHNwtpJshtR6WQE8mszRlk53A=
+github.com/canonical/gomaasclient v0.9.0 h1:zInnFepRxjOYdWD35FN7qaiAzwLAf2sRshZCTC5HlJ8=
+github.com/canonical/gomaasclient v0.9.0/go.mod h1:VS99xiJeSCUCqd574qNHNwtpJshtR6WQE8mszRlk53A=
 github.com/cloudflare/circl v1.3.7 h1:qlCDlTPz2n9fu58M0Nh1J/JzcFpfgkFHHX3O35r5vcU=
 github.com/cloudflare/circl v1.3.7/go.mod h1:sRTcRWXGLrKw6yIGJ+l7amYJFfAXbZG0kBSc8r4zxgA=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Description of changes

Bumps gomaasclient version from 0.8.0 -> 0.9.0 to use the VLAN DHCP setter update.

## Issue or ticket link (if applicable)

NA.

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type(scope): title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
