### PR TITLE
feat: 72-erase-disks-when-destroying-instances

### DIFF
--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -42,6 +42,7 @@ resource "maas_instance" "kvm" {
 - `allocate_params` (Block List, Max: 1) Nested argument with the constraints used to machine allocation. Defined below. (see [below for nested schema](#nestedblock--allocate_params))
 - `deploy_params` (Block List, Max: 1) Nested argument with the config used to deploy the allocated machine. Defined below. (see [below for nested schema](#nestedblock--deploy_params))
 - `network_interfaces` (Block Set) Specifies a network interface configuration done before the machine is deployed. Parameters defined below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). (see [below for nested schema](#nestedblock--network_interfaces))
+- `release_params` (Block List, Max: 1) Parameters used to release the allocated machine. Only used when the machine is released upon resource destroy. (see [below for nested schema](#nestedblock--release_params))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -95,6 +96,18 @@ Optional:
 
 **NOTE:** If both `subnet_cidr` and `ip_address` are not defined, the interface will not be configured on the allocated machine.
 - `subnet_cidr` (String) An existing subnet CIDR used to configure the network interface. Unless `ip_address` is defined, a free IP address is allocated from the subnet.
+
+
+<a id="nestedblock--release_params"></a>
+### Nested Schema for `release_params`
+
+Optional:
+
+- `comment` (String) A comment to be added to the event log when the machine is released.
+- `erase` (Boolean) Erase the disk when releasing.
+- `force` (Boolean) Force the release of the machine. If the machine was deployed as a KVM host, all machines inside the host will be deleted. Use with caution.
+- `quick_erase` (Boolean) Use quick erase. Wipe 2MiB at the start and at the end of the drive to make data recovery inconvenient and unlikely to happen by accident. This is not secure.
+- `secure_erase` (Boolean) Use the drive's secure erase feature if available.  In some cases, this can be much faster than overwriting the drive. Some drives implement secure erasure by overwriting themselves so this could still be slow.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -42,7 +42,7 @@ resource "maas_instance" "kvm" {
 - `allocate_params` (Block List, Max: 1) Nested argument with the constraints used to machine allocation. Defined below. (see [below for nested schema](#nestedblock--allocate_params))
 - `deploy_params` (Block List, Max: 1) Nested argument with the config used to deploy the allocated machine. Defined below. (see [below for nested schema](#nestedblock--deploy_params))
 - `network_interfaces` (Block Set) Specifies a network interface configuration done before the machine is deployed. Parameters defined below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). (see [below for nested schema](#nestedblock--network_interfaces))
-- `release_params` (Block List, Max: 1) Parameters used to release the allocated machine. Only used when the machine is released upon resource destroy. (see [below for nested schema](#nestedblock--release_params))
+- `release_params` (Block List, Max: 1) Parameters used to release the allocated machine. Used when the machine is released upon destroy. (see [below for nested schema](#nestedblock--release_params))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -42,7 +42,7 @@ resource "maas_instance" "kvm" {
 - `allocate_params` (Block List, Max: 1) Nested argument with the constraints used to machine allocation. Defined below. (see [below for nested schema](#nestedblock--allocate_params))
 - `deploy_params` (Block List, Max: 1) Nested argument with the config used to deploy the allocated machine. Defined below. (see [below for nested schema](#nestedblock--deploy_params))
 - `network_interfaces` (Block Set) Specifies a network interface configuration done before the machine is deployed. Parameters defined below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). (see [below for nested schema](#nestedblock--network_interfaces))
-- `release_params` (Block List, Max: 1) Parameters used to release the allocated machine. Used when the machine is released upon destroy. (see [below for nested schema](#nestedblock--release_params))
+- `release_params` (Block List, Max: 1) Parameters used to release the allocated machine when the resource is destroyed. (see [below for nested schema](#nestedblock--release_params))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/instance.md
+++ b/docs/resources/instance.md
@@ -105,7 +105,7 @@ Optional:
 
 - `comment` (String) A comment to be added to the event log when the machine is released.
 - `erase` (Boolean) Erase the disk when releasing.
-- `force` (Boolean) Force the release of the machine. If the machine was deployed as a KVM host, all machines inside the host will be deleted. Use with caution.
+- `force` (Boolean) Force the release of the machine.
 - `quick_erase` (Boolean) Use quick erase. Wipe 2MiB at the start and at the end of the drive to make data recovery inconvenient and unlikely to happen by accident. This is not secure.
 - `secure_erase` (Boolean) Use the drive's secure erase feature if available.  In some cases, this can be much faster than overwriting the drive. Some drives implement secure erasure by overwriting themselves so this could still be slow.
 

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -197,6 +197,42 @@ func resourceMAASInstance() *schema.Resource {
 				Computed:    true,
 				Description: "The deployed MAAS machine pool name.",
 			},
+			"release_params": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				MaxItems:    1,
+				Description: "Parameters used to release the allocated machine. Only used when the machine is released upon resource destroy.",
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"comment": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: "A comment to be added to the event log when the machine is released.",
+						},
+						"erase": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Erase the disk when releasing.",
+						},
+						"force": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Force the release of the machine. If the machine was deployed as a KVM host, all machines inside the host will be deleted. Use with caution.",
+						},
+						"quick_erase": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							
+							Description: "Use quick erase. Wipe 2MiB at the start and at the end of the drive to make data recovery inconvenient and unlikely to happen by accident. This is not secure.",
+						},
+						"secure_erase": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Use the drive's secure erase feature if available.  In some cases, this can be much faster than overwriting the drive. Some drives implement secure erasure by overwriting themselves so this could still be slow.",
+						},
+					},
+				},
+			},
 			"tags": {
 				Type:        schema.TypeSet,
 				Computed:    true,
@@ -286,8 +322,10 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*ClientConfig).Client
 
+	releaseParams := getReleaseParams(d)
+
 	// Release MAAS machine
-	err := client.Machines.Release([]string{d.Id()}, "Released by Terraform")
+	_, err := client.Machine.Release(d.Id(), releaseParams)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -339,6 +377,25 @@ func getMachineDeployParams(d *schema.ResourceData) *entity.MachineDeployParams 
 	}
 
 	return &entity.MachineDeployParams{}
+}
+
+func getReleaseParams(d *schema.ResourceData) *entity.MachineReleaseParams {
+	if p, ok := d.GetOk("release_params"); ok {
+		releaseParamsData := p.([]any)
+		if releaseParamsData[0] != nil {
+			releaseParams := releaseParamsData[0].(map[string]any)
+
+			return &entity.MachineReleaseParams{
+				Comment:      releaseParams["comment"].(string),
+				Erase:        releaseParams["erase"].(bool),
+				Force:        releaseParams["force"].(bool),
+				QuickErase:   releaseParams["quick_erase"].(bool),
+				SecureErase:  releaseParams["secure_erase"].(bool),
+			}
+		}
+	}
+
+	return &entity.MachineReleaseParams{}
 }
 
 func configureInstanceNetworkInterfaces(client *client.Client, d *schema.ResourceData, machine *entity.Machine) error {

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -202,7 +202,7 @@ func resourceMAASInstance() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Parameters used to release the allocated machine. Only used when the machine is released upon resource destroy.",
+				Description: "Parameters used to release the allocated machine. Used when the machine is released upon destroy.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"comment": {
@@ -320,23 +320,7 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 }
 
 func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
-	if d.HasChange("release_params") {
-		if _, ok := d.GetOk("release_params"); ok {
-			releaseParams := getReleaseParams(d)
-
-			releaseParamMap := map[string]any{
-				"comment":      releaseParams.Comment,
-				"erase":        releaseParams.Erase,
-				"force":        releaseParams.Force,
-				"quick_erase":  releaseParams.QuickErase,
-				"secure_erase": releaseParams.SecureErase,
-			}
-			if err := d.Set("release_params", []map[string]any{releaseParamMap}); err != nil {
-				return diag.FromErr(err)
-			}
-		}
-	}
-
+	// Dummy update to allow release params to be updated.
 	return resourceInstanceRead(ctx, d, meta)
 }
 

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -218,7 +218,7 @@ func resourceMAASInstance() *schema.Resource {
 						"force": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "Force the release of the machine. If the machine was deployed as a KVM host, all machines inside the host will be deleted. Use with caution.",
+							Description: "Force the release of the machine.",
 						},
 						"quick_erase": {
 							Type:        schema.TypeBool,

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -353,7 +353,7 @@ func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta an
 	}
 
 	// Wait MAAS machine to be released
-	_, err = waitForMachineStatus(ctx, client, d.Id(), []string{"Releasing"}, []string{"Ready"}, d.Timeout(schema.TimeoutDelete))
+	_, err = waitForMachineStatus(ctx, client, d.Id(), []string{"Releasing", "Disk erasing"}, []string{"Ready"}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -202,7 +202,7 @@ func resourceMAASInstance() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Parameters used to release the allocated machine. Used when the machine is released upon destroy.",
+				Description: "Parameters used to release the allocated machine when the resource is destroyed.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"comment": {

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -223,7 +223,6 @@ func resourceMAASInstance() *schema.Resource {
 						"quick_erase": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							
 							Description: "Use quick erase. Wipe 2MiB at the start and at the end of the drive to make data recovery inconvenient and unlikely to happen by accident. This is not secure.",
 						},
 						"secure_erase": {
@@ -325,17 +324,15 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 		if _, ok := d.GetOk("release_params"); ok {
 			releaseParams := getReleaseParams(d)
 			releaseParamMap := map[string]any{
-				"comment":	  releaseParams.Comment,
+				"comment":	  	releaseParams.Comment,
 				"erase":        releaseParams.Erase,
 				"force": 		releaseParams.Force,
 				"quick_erase": 	releaseParams.QuickErase,
 				"secure_erase": releaseParams.SecureErase,
 			}
-			err := setTerraformState(d, releaseParamMap)
-			if err != nil {
+			if err := d.Set("release_params", []map[string]any{releaseParamMap}); err != nil {
 				return diag.FromErr(err)
 			}
-			
 		}
 	}
 	return resourceInstanceRead(ctx, d, meta)

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -18,6 +18,7 @@ func resourceMAASInstance() *schema.Resource {
 		CreateContext: resourceInstanceCreate,
 		ReadContext:   resourceInstanceRead,
 		DeleteContext: resourceInstanceDelete,
+		UpdateContext: resourceInstanceUpdate,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				client := meta.(*ClientConfig).Client
@@ -317,6 +318,27 @@ func resourceInstanceRead(ctx context.Context, d *schema.ResourceData, meta any)
 	}
 
 	return nil
+}
+
+func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+	if d.HasChange("release_params") {
+		if _, ok := d.GetOk("release_params"); ok {
+			releaseParams := getReleaseParams(d)
+			releaseParamMap := map[string]any{
+				"comment":	  releaseParams.Comment,
+				"erase":        releaseParams.Erase,
+				"force": 		releaseParams.Force,
+				"quick_erase": 	releaseParams.QuickErase,
+				"secure_erase": releaseParams.SecureErase,
+			}
+			err := setTerraformState(d, releaseParamMap)
+			if err != nil {
+				return diag.FromErr(err)
+			}
+			
+		}
+	}
+	return resourceInstanceRead(ctx, d, meta)
 }
 
 func resourceInstanceDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/maas/resource_maas_instance.go
+++ b/maas/resource_maas_instance.go
@@ -323,11 +323,12 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 	if d.HasChange("release_params") {
 		if _, ok := d.GetOk("release_params"); ok {
 			releaseParams := getReleaseParams(d)
+
 			releaseParamMap := map[string]any{
-				"comment":	  	releaseParams.Comment,
+				"comment":      releaseParams.Comment,
 				"erase":        releaseParams.Erase,
-				"force": 		releaseParams.Force,
-				"quick_erase": 	releaseParams.QuickErase,
+				"force":        releaseParams.Force,
+				"quick_erase":  releaseParams.QuickErase,
 				"secure_erase": releaseParams.SecureErase,
 			}
 			if err := d.Set("release_params", []map[string]any{releaseParamMap}); err != nil {
@@ -335,6 +336,7 @@ func resourceInstanceUpdate(ctx context.Context, d *schema.ResourceData, meta an
 			}
 		}
 	}
+
 	return resourceInstanceRead(ctx, d, meta)
 }
 
@@ -405,11 +407,11 @@ func getReleaseParams(d *schema.ResourceData) *entity.MachineReleaseParams {
 			releaseParams := releaseParamsData[0].(map[string]any)
 
 			return &entity.MachineReleaseParams{
-				Comment:      releaseParams["comment"].(string),
-				Erase:        releaseParams["erase"].(bool),
-				Force:        releaseParams["force"].(bool),
-				QuickErase:   releaseParams["quick_erase"].(bool),
-				SecureErase:  releaseParams["secure_erase"].(bool),
+				Comment:     releaseParams["comment"].(string),
+				Erase:       releaseParams["erase"].(bool),
+				Force:       releaseParams["force"].(bool),
+				QuickErase:  releaseParams["quick_erase"].(bool),
+				SecureErase: releaseParams["secure_erase"].(bool),
 			}
 		}
 	}

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -10,26 +10,24 @@ import (
 	"terraform-provider-maas/maas/testutils"
 	"testing"
 
+	"github.com/canonical/gomaasclient/entity"
+	"github.com/canonical/gomaasclient/entity/node"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/canonical/gomaasclient/entity"
-	"github.com/canonical/gomaasclient/entity/node"
-
 )
 
 func TestAccResourceMAASInstance_basic(t *testing.T) {
 	// Required to check if the machine is released into its read state after destroy
-	var machine entity.Machine  
+	var machine entity.Machine
 
-	vm_host := os.Getenv("TF_ACC_VM_HOST_ID")
+	vmHost := os.Getenv("TF_ACC_VM_HOST_ID")
 	hostname := acctest.RandomWithPrefix("tf-instance")
 	comment := acctest.RandomWithPrefix("tf-instance-comment")
 	erase := "true"
 	force := "false"
-	quick_erase := "true"
-	secure_erase := "false"
-
+	quickErase := "true"
+	secureErase := "false"
 
 	baseChecks := []resource.TestCheckFunc{
 		testAccMAASInstanceCheckExists("maas_instance.test", &machine),
@@ -39,33 +37,34 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck: func() {testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"})},
-		Providers: testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
+		Providers:    testutils.TestAccProviders,
+		ErrorCheck:   func(err error) error { return err },
+		CheckDestroy: testAccMAASInstanceCheckDestroy,
 		Steps: []resource.TestStep{
 			// Test creation
 			{
-				Config: testAccMAASInstanceConfigBasic(vm_host, hostname),
-				Check: resource.ComposeTestCheckFunc(baseChecks...),
+				Config: testAccMAASInstanceConfigBasic(vmHost, hostname),
+				Check:  resource.ComposeTestCheckFunc(baseChecks...),
 			},
 			// Test update
 			{
-				Config: testAccMAASInstanceConfigSetup(vm_host, hostname)  + testAccMAASInstanceConfigReleaseParams(comment, erase, force, quick_erase, secure_erase),
+				Config: testAccMAASInstanceConfigSetup(vmHost, hostname) + testAccMAASInstanceConfigReleaseParams(comment, erase, force, quickErase, secureErase),
 				Check: resource.ComposeTestCheckFunc(append(
-					baseChecks, 
+					baseChecks,
 					resource.TestCheckResourceAttr("maas_instance.test", "release_params.#", "1"),
 					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.comment", comment),
 					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.erase", erase),
 					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.force", force),
-					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", quick_erase),
-					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.secure_erase", secure_erase),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", quickErase),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.secure_erase", secureErase),
 				)...,
 				),
 			},
 			// Test destroy leaves the machine in a ready state
 			{
-				Config: testAccMAASInstanceConfigSetup(vm_host, hostname),
-				Check: testAccMAASInstanceCheckMachineInStatus(machine.SystemID, node.StatusReady),
+				Config: testAccMAASInstanceConfigSetup(vmHost, hostname),
+				Check:  testAccMAASInstanceCheckMachineInStatus(machine.SystemID, node.StatusReady),
 			},
 		},
 	})
@@ -88,7 +87,6 @@ func testAccMAASInstanceCheckMachineInStatus(systemID string, status node.Status
 	}
 }
 
-
 func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Get the terraform resource from state
@@ -96,6 +94,7 @@ func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource
 		if !ok {
 			return fmt.Errorf("not found: %s", rn)
 		}
+
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set: %s", rn)
 		}
@@ -107,6 +106,7 @@ func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource
 		if err != nil {
 			return err
 		}
+
 		if gotMachine.SystemID != rs.Primary.ID {
 			return fmt.Errorf("machine ID %s does not match expected id %s", gotMachine.SystemID, rs.Primary.ID)
 		}
@@ -119,6 +119,7 @@ func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource
 
 func testAccMAASInstanceCheckDestroy(s *terraform.State) error {
 	conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "maas_instance" {
 			continue
@@ -130,7 +131,7 @@ func testAccMAASInstanceCheckDestroy(s *terraform.State) error {
 			if response != nil && response.SystemID == rs.Primary.ID {
 				return fmt.Errorf("instance %s still exists", rs.Primary.ID)
 			}
-		} 
+		}
 
 		// If the error is equivalent to a 404, the instance was destroyed as expected.
 		if !strings.Contains(err.Error(), "404 Not Found") {
@@ -141,9 +142,9 @@ func testAccMAASInstanceCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccMAASInstanceConfigSetup(vm_host, hostname string) string {
+func testAccMAASInstanceConfigSetup(vmHost, hostname string) string {
 	return fmt.Sprintf(
-`
+		`
 resource "maas_vm_host_machine" "test" {
   vm_host  = %q
   cores    = 1
@@ -151,10 +152,10 @@ resource "maas_vm_host_machine" "test" {
   hostname = %q
 }
 
-`, vm_host, hostname)
-	}
+`, vmHost, hostname)
+}
 
-func testAccMAASInstanceConfigBasic(vm_host, hostname string) string {
+func testAccMAASInstanceConfigBasic(vmHost, hostname string) string {
 	return fmt.Sprintf(`
 %s 
 
@@ -165,13 +166,12 @@ resource "maas_instance" "test" {
     min_cpu_count = 1
   }
 }
-`, testAccMAASInstanceConfigSetup(vm_host, hostname),)
+`, testAccMAASInstanceConfigSetup(vmHost, hostname))
 }
 
-
-func testAccMAASInstanceConfigReleaseParams(comment, erase, force, quick_erase, secure_erase string) string {
+func testAccMAASInstanceConfigReleaseParams(comment, erase, force, quickErase, secureErase string) string {
 	return fmt.Sprintf(
-`
+		`
 resource "maas_instance" "test" {
   release_params {
     comment      = %q
@@ -188,5 +188,5 @@ resource "maas_instance" "test" {
   }
 
 }
-`, comment, erase, force, quick_erase, secure_erase)
-	}
+`, comment, erase, force, quickErase, secureErase)
+}

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -10,7 +10,6 @@ import (
 	"terraform-provider-maas/maas/testutils"
 	"testing"
 
-	"github.com/canonical/gomaasclient/entity"
 	"github.com/canonical/gomaasclient/entity/node"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -18,9 +17,6 @@ import (
 )
 
 func TestAccResourceMAASInstance_basic(t *testing.T) {
-	// Required to check if the machine is released into its read state after destroy
-	var machine entity.Machine
-
 	vmHost := os.Getenv("TF_ACC_VM_HOST_ID")
 	hostname := acctest.RandomWithPrefix("tf-instance")
 	comment := acctest.RandomWithPrefix("tf-instance-comment")
@@ -30,7 +26,7 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 	secureErase := "false"
 
 	baseChecks := []resource.TestCheckFunc{
-		testAccMAASInstanceCheckExists("maas_instance.test", &machine),
+		testAccMAASInstanceCheckExists("maas_instance.test"),
 		resource.TestCheckResourceAttr("maas_instance.test", "hostname", hostname),
 		resource.TestCheckResourceAttr("maas_instance.test", "memory", "4096"),
 		resource.TestCheckResourceAttr("maas_instance.test", "cpu_count", "1"),
@@ -64,32 +60,34 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 			// Test destroy leaves the machine in a ready state
 			{
 				Config: testAccMAASInstanceConfigSetup(vmHost, hostname),
-				Check:  testAccMAASInstanceCheckMachineInStatus(machine.SystemID, node.StatusReady),
+				Check:  testAccMAASInstanceCheckMachineInStatus("maas_vm_host_machine.test", node.StatusReady),
 			},
 		},
 	})
 }
 
-func testAccMAASInstanceCheckMachineInStatus(systemID string, status node.Status) resource.TestCheckFunc {
+func testAccMAASInstanceCheckMachineInStatus(rn string, status node.Status) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("not found: %s", rn)
+		}
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
-
-		machine, err := conn.Machine.Get(systemID)
+		machine, err := conn.Machine.Get(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 
 		if machine.Status != status {
-			return fmt.Errorf("machine %s is not in the expected status %d but in status %d", systemID, status, machine.Status)
+			return fmt.Errorf("machine %s is not in the expected status %d but in status %d", rs.Primary.ID, status, machine.Status)
 		}
 
 		return nil
 	}
 }
 
-func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource.TestCheckFunc {
+func testAccMAASInstanceCheckExists(rn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Get the terraform resource from state
 		rs, ok := s.RootModule().Resources[rn]
 		if !ok {
 			return fmt.Errorf("not found: %s", rn)
@@ -101,7 +99,6 @@ func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource
 
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
 
-		// Check if the resource exists in MAAS
 		gotMachine, err := conn.Machine.Get(rs.Primary.ID)
 		if err != nil {
 			return err
@@ -110,8 +107,6 @@ func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource
 		if gotMachine.SystemID != rs.Primary.ID {
 			return fmt.Errorf("machine ID %s does not match expected id %s", gotMachine.SystemID, rs.Primary.ID)
 		}
-
-		*machine = *gotMachine
 
 		return nil
 	}

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -72,7 +72,9 @@ func testAccMAASInstanceCheckMachineInStatus(rn string, status node.Status) reso
 		if !ok {
 			return fmt.Errorf("not found: %s", rn)
 		}
+
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
 		machine, err := conn.Machine.Get(rs.Primary.ID)
 		if err != nil {
 			return err

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -1,0 +1,133 @@
+package maas_test
+
+import (
+	// "encoding/json"
+	"fmt"
+	"os"
+
+	"strings"
+	"terraform-provider-maas/maas"
+	"terraform-provider-maas/maas/testutils"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceMAASInstance_basic(t *testing.T) {
+	vm_host := os.Getenv("TF_ACC_VM_HOST_ID")
+	hostname := acctest.RandomWithPrefix("tf-instance")
+	comment := acctest.RandomWithPrefix("tf-instance-comment")
+	erase := true
+	force := false
+	quick_erase := true
+	secure_erase := false
+
+	checks := []resource.TestCheckFunc{
+		testAccMAASInstanceCheckExists("maas_instance.test"),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.comment", comment),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.erase", "true"),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", "true"),
+		resource.TestCheckResourceAttr("maas_instance.test", "hostname", hostname),
+		resource.TestCheckResourceAttr("maas_instance.test", "memory", "4096"),
+	}
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck: func() {testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"})},
+		Providers: testutils.TestAccProviders,
+		ErrorCheck: func(err error) error { return err },
+		Steps: []resource.TestStep{
+			{
+				Config: testAccMAASInstanceConfigSetup(vm_host, hostname) + testAccMAASInstanceConfig(comment, erase, force, quick_erase, secure_erase),
+				Check: resource.ComposeTestCheckFunc(checks...),
+			},
+		},
+	})
+}
+
+func testAccMAASInstanceCheckExists(rn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set: %s", rn)
+		}
+
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
+
+		machine, err := conn.Machine.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if machine.SystemID != rs.Primary.ID {
+			return fmt.Errorf("machine ID %s does not match expected id %s", machine.SystemID, rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+func testAccMAASInstanceCheckDestroy(s *terraform.State) error {
+	conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "maas_instance" {
+			continue
+		}
+
+		// Get the machine from maas and check if it exists
+		response, err := conn.Machine.Get(rs.Primary.ID)
+		if err == nil {
+			if response != nil && response.SystemID == rs.Primary.ID {
+				return fmt.Errorf("instance %s still exists", rs.Primary.ID)
+			}
+		} 
+
+		// If the error is equivalent to a 404, the instance was destroyed as expected.
+		if !strings.Contains(err.Error(), "404 Not Found") {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccMAASInstanceConfigSetup(vm_host string, hostname string) string {
+	return fmt.Sprintf(
+`
+resource "maas_vm_host_machine" "test" {
+  vm_host  = %q
+  cores    = 1
+  memory   = 4096 # set to above the default
+  hostname = %q
+}
+
+`, vm_host, hostname)
+	}
+
+func testAccMAASInstanceConfig(comment string, erase, force, quick_erase, secure_erase bool) string {
+	return fmt.Sprintf(
+`
+resource "maas_instance" "test" {
+  release_params {
+    comment      = %q
+    erase        = %q
+    force        = %q
+    quick_erase  = %q
+    secure_erase = %q	
+  }
+
+  allocate_params {
+    hostname      = maas_vm_host_machine.test.hostname
+    min_memory    = 4096
+    min_cpu_count = 1
+  }
+
+}
+`, comment, erase, force, quick_erase, secure_erase)
+	}

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -102,7 +102,7 @@ func testAccMAASInstanceCheckMachineLogsForDestroy(hostname string, erase bool) 
 			return fmt.Errorf("machine %s was not released as expected", hostname)
 		}
 
-		if !wasErased && erase {
+		if wasErased != erase {
 			return fmt.Errorf("machine %s did not have disks erased as expected", hostname)
 		}
 

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -53,23 +53,22 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 
 func testAccMAASInstanceCheckExists(rn string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
+		// Get the terraform resource from state
 		rs, ok := s.RootModule().Resources[rn]
 		if !ok {
 			return fmt.Errorf("not found: %s", rn)
 		}
-
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("resource id not set: %s", rn)
 		}
 
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
 
-
+		// Check if the resource exists in MAAS
 		machine, err := conn.Machine.Get(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-
 		if machine.SystemID != rs.Primary.ID {
 			return fmt.Errorf("machine ID %s does not match expected id %s", machine.SystemID, rs.Primary.ID)
 		}

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -19,18 +19,22 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 	vm_host := os.Getenv("TF_ACC_VM_HOST_ID")
 	hostname := acctest.RandomWithPrefix("tf-instance")
 	comment := acctest.RandomWithPrefix("tf-instance-comment")
-	erase := true
-	force := false
-	quick_erase := true
-	secure_erase := false
+	erase := "true"
+	force := "false"
+	quick_erase := "true"
+	secure_erase := "false"
 
 	checks := []resource.TestCheckFunc{
 		testAccMAASInstanceCheckExists("maas_instance.test"),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.#", "1"),
 		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.comment", comment),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.erase", "true"),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", "true"),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.erase", erase),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.force", force),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", quick_erase),
+		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.secure_erase", secure_erase),
 		resource.TestCheckResourceAttr("maas_instance.test", "hostname", hostname),
 		resource.TestCheckResourceAttr("maas_instance.test", "memory", "4096"),
+		resource.TestCheckResourceAttr("maas_instance.test", "cpu_count", "1"),
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -38,6 +42,7 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 		Providers: testutils.TestAccProviders,
 		ErrorCheck: func(err error) error { return err },
 		Steps: []resource.TestStep{
+			// Test creation
 			{
 				Config: testAccMAASInstanceConfigSetup(vm_host, hostname) + testAccMAASInstanceConfig(comment, erase, force, quick_erase, secure_erase),
 				Check: resource.ComposeTestCheckFunc(checks...),
@@ -103,14 +108,14 @@ func testAccMAASInstanceConfigSetup(vm_host string, hostname string) string {
 resource "maas_vm_host_machine" "test" {
   vm_host  = %q
   cores    = 1
-  memory   = 4096 # set to above the default
+  memory   = 4096  # set to above the default
   hostname = %q
 }
 
 `, vm_host, hostname)
 	}
 
-func testAccMAASInstanceConfig(comment string, erase, force, quick_erase, secure_erase bool) string {
+func testAccMAASInstanceConfig(comment, erase, force, quick_erase, secure_erase string) string {
 	return fmt.Sprintf(
 `
 resource "maas_instance" "test" {

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -9,6 +9,7 @@ import (
 	"terraform-provider-maas/maas"
 	"terraform-provider-maas/maas/testutils"
 	"testing"
+
 	"github.com/canonical/gomaasclient/entity"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -73,6 +74,7 @@ func testAccMAASInstanceCheckMachineLogsForDestroy(hostname string, erase bool) 
 		params := entity.EventParams{
 			Hostname: hostname,
 		}
+
 		events, err := conn.Events.Get(&params)
 		if err != nil {
 			return err
@@ -85,10 +87,12 @@ func testAccMAASInstanceCheckMachineLogsForDestroy(hostname string, erase bool) 
 		// Check through all events to see if the machine was released as expected
 		wasErased := false
 		wasReleased := false
+
 		for _, event := range events.Events {
 			if event.Type == "Disks erased" {
 				wasErased = true
 			}
+
 			if event.Type == "Released" {
 				wasReleased = true
 			}

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -13,9 +13,15 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/canonical/gomaasclient/entity"
+	"github.com/canonical/gomaasclient/entity/node"
+
 )
 
 func TestAccResourceMAASInstance_basic(t *testing.T) {
+	// Required to check if the machine is released into its read state after destroy
+	var machine entity.Machine  
+
 	vm_host := os.Getenv("TF_ACC_VM_HOST_ID")
 	hostname := acctest.RandomWithPrefix("tf-instance")
 	comment := acctest.RandomWithPrefix("tf-instance-comment")
@@ -24,14 +30,9 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 	quick_erase := "true"
 	secure_erase := "false"
 
-	checks := []resource.TestCheckFunc{
-		testAccMAASInstanceCheckExists("maas_instance.test"),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.#", "1"),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.comment", comment),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.erase", erase),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.force", force),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", quick_erase),
-		resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.secure_erase", secure_erase),
+
+	baseChecks := []resource.TestCheckFunc{
+		testAccMAASInstanceCheckExists("maas_instance.test", &machine),
 		resource.TestCheckResourceAttr("maas_instance.test", "hostname", hostname),
 		resource.TestCheckResourceAttr("maas_instance.test", "memory", "4096"),
 		resource.TestCheckResourceAttr("maas_instance.test", "cpu_count", "1"),
@@ -44,14 +45,51 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Test creation
 			{
-				Config: testAccMAASInstanceConfigSetup(vm_host, hostname) + testAccMAASInstanceConfig(comment, erase, force, quick_erase, secure_erase),
-				Check: resource.ComposeTestCheckFunc(checks...),
+				Config: testAccMAASInstanceConfigBasic(vm_host, hostname),
+				Check: resource.ComposeTestCheckFunc(baseChecks...),
+			},
+			// Test update
+			{
+				Config: testAccMAASInstanceConfigSetup(vm_host, hostname)  + testAccMAASInstanceConfigReleaseParams(comment, erase, force, quick_erase, secure_erase),
+				Check: resource.ComposeTestCheckFunc(append(
+					baseChecks, 
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.#", "1"),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.comment", comment),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.erase", erase),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.force", force),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.quick_erase", quick_erase),
+					resource.TestCheckResourceAttr("maas_instance.test", "release_params.0.secure_erase", secure_erase),
+				)...,
+				),
+			},
+			// Test destroy leaves the machine in a ready state
+			{
+				Config: testAccMAASInstanceConfigSetup(vm_host, hostname),
+				Check: testAccMAASInstanceCheckMachineInStatus(machine.SystemID, node.StatusReady),
 			},
 		},
 	})
 }
 
-func testAccMAASInstanceCheckExists(rn string) resource.TestCheckFunc {
+func testAccMAASInstanceCheckMachineInStatus(systemID string, status node.Status) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
+		machine, err := conn.Machine.Get(systemID)
+		if err != nil {
+			return err
+		}
+
+		if machine.Status != status {
+			return fmt.Errorf("machine %s is not in the expected status %d but in status %d", systemID, status, machine.Status)
+		}
+
+		return nil
+	}
+}
+
+
+func testAccMAASInstanceCheckExists(rn string, machine *entity.Machine) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Get the terraform resource from state
 		rs, ok := s.RootModule().Resources[rn]
@@ -65,13 +103,15 @@ func testAccMAASInstanceCheckExists(rn string) resource.TestCheckFunc {
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
 
 		// Check if the resource exists in MAAS
-		machine, err := conn.Machine.Get(rs.Primary.ID)
+		gotMachine, err := conn.Machine.Get(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		if machine.SystemID != rs.Primary.ID {
-			return fmt.Errorf("machine ID %s does not match expected id %s", machine.SystemID, rs.Primary.ID)
+		if gotMachine.SystemID != rs.Primary.ID {
+			return fmt.Errorf("machine ID %s does not match expected id %s", gotMachine.SystemID, rs.Primary.ID)
 		}
+
+		*machine = *gotMachine
 
 		return nil
 	}
@@ -101,7 +141,7 @@ func testAccMAASInstanceCheckDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccMAASInstanceConfigSetup(vm_host string, hostname string) string {
+func testAccMAASInstanceConfigSetup(vm_host, hostname string) string {
 	return fmt.Sprintf(
 `
 resource "maas_vm_host_machine" "test" {
@@ -114,7 +154,22 @@ resource "maas_vm_host_machine" "test" {
 `, vm_host, hostname)
 	}
 
-func testAccMAASInstanceConfig(comment, erase, force, quick_erase, secure_erase string) string {
+func testAccMAASInstanceConfigBasic(vm_host, hostname string) string {
+	return fmt.Sprintf(`
+%s 
+
+resource "maas_instance" "test" {
+  allocate_params {
+    hostname      = maas_vm_host_machine.test.hostname
+    min_memory    = 4000
+    min_cpu_count = 1
+  }
+}
+`, testAccMAASInstanceConfigSetup(vm_host, hostname),)
+}
+
+
+func testAccMAASInstanceConfigReleaseParams(comment, erase, force, quick_erase, secure_erase string) string {
 	return fmt.Sprintf(
 `
 resource "maas_instance" "test" {
@@ -128,7 +183,7 @@ resource "maas_instance" "test" {
 
   allocate_params {
     hostname      = maas_vm_host_machine.test.hostname
-    min_memory    = 4096
+    min_memory    = 4000
     min_cpu_count = 1
   }
 

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -9,8 +9,7 @@ import (
 	"terraform-provider-maas/maas"
 	"terraform-provider-maas/maas/testutils"
 	"testing"
-
-	"github.com/canonical/gomaasclient/entity/node"
+	"github.com/canonical/gomaasclient/entity"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -60,28 +59,47 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 			// Test destroy leaves the machine in a ready state
 			{
 				Config: testAccMAASInstanceConfigSetup(vmHost, hostname),
-				Check:  testAccMAASInstanceCheckMachineInStatus("maas_vm_host_machine.test", node.StatusReady),
+				Check:  testAccMAASInstanceCheckMachineLogsForDestroy(hostname, erase == "true"),
 			},
 		},
 	})
 }
 
-func testAccMAASInstanceCheckMachineInStatus(rn string, status node.Status) resource.TestCheckFunc {
+// Check logs for relevant events to determine if the machine was released as expected during destroy
+func testAccMAASInstanceCheckMachineLogsForDestroy(hostname string, erase bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[rn]
-		if !ok {
-			return fmt.Errorf("not found: %s", rn)
-		}
-
 		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
 
-		machine, err := conn.Machine.Get(rs.Primary.ID)
+		params := entity.EventParams{
+			Hostname: hostname,
+		}
+		events, err := conn.Events.Get(&params)
 		if err != nil {
 			return err
 		}
 
-		if machine.Status != status {
-			return fmt.Errorf("machine %s is not in the expected status %d but in status %d", rs.Primary.ID, status, machine.Status)
+		if len(events.Events) == 0 {
+			return fmt.Errorf("no events found for hostname %s", hostname)
+		}
+
+		// Check through all events to see if the machine was released as expected
+		wasErased := false
+		wasReleased := false
+		for _, event := range events.Events {
+			if event.Type == "Disks erased" {
+				wasErased = true
+			}
+			if event.Type == "Released" {
+				wasReleased = true
+			}
+		}
+
+		if !wasReleased {
+			return fmt.Errorf("machine %s was not released as expected", hostname)
+		}
+
+		if !wasErased && erase {
+			return fmt.Errorf("machine %s did not have disks erased as expected", hostname)
 		}
 
 		return nil


### PR DESCRIPTION
## Description of changes

Add ability to erase disks when destroying the resource `maas_instance`. 

## Issue or ticket link (if applicable)

Resolves: #72 
Resolves: #260

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type(scope): title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
