### PR TITLE
refactor: Update user resource

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -13,11 +13,19 @@ Provides a resource to manage MAAS users.
 ## Example Usage
 
 ```terraform
-resource "maas_user" "cloudbase" {
-  name     = "cloudbase"
-  password = "Passw0rd123"
-  email    = "admin@cloudbase.local"
+resource "maas_user" "maas_admin" {
+  name     = "maas_admin"
+  password = "P8ssw0rd12"
+  email    = "admin@maas.com"
   is_admin = true
+}
+
+resource "maas_user" "cloudbase" {
+  name             = "cloudbase"
+  password         = "Passw0rd123"
+  email            = "admin@cloudbase.local"
+  is_admin         = true
+  transfer_to_user = maas_admin.name
 }
 ```
 
@@ -33,10 +41,12 @@ resource "maas_user" "cloudbase" {
 ### Optional
 
 - `is_admin` (Boolean) Boolean value indicating if the user is a MAAS administrator. Defaults to `false`.
+- `transfer_to_user` (String) If provided, resources owned by the deleted user will be transfered to this user.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `is_local` (Boolean) Boolean value indicating if the user is a local MAAS account. Defaults to `true`.
 
 ## Import
 

--- a/examples/resources/maas_user/resource.tf
+++ b/examples/resources/maas_user/resource.tf
@@ -1,6 +1,14 @@
-resource "maas_user" "cloudbase" {
-  name     = "cloudbase"
-  password = "Passw0rd123"
-  email    = "admin@cloudbase.local"
+resource "maas_user" "maas_admin" {
+  name     = "maas_admin"
+  password = "P8ssw0rd12"
+  email    = "admin@maas.com"
   is_admin = true
+}
+
+resource "maas_user" "cloudbase" {
+  name             = "cloudbase"
+  password         = "Passw0rd123"
+  email            = "admin@cloudbase.local"
+  is_admin         = true
+  transfer_to_user = maas_admin.name
 }

--- a/maas/resource_maas_user.go
+++ b/maas/resource_maas_user.go
@@ -29,6 +29,7 @@ func resourceMAASUser() *schema.Resource {
 					"name":     user.UserName,
 					"email":    user.Email,
 					"is_admin": user.IsSuperUser,
+					"is_local": user.IsLocal,
 				}
 				if err := setTerraformState(d, tfState); err != nil {
 					return nil, err
@@ -52,6 +53,12 @@ func resourceMAASUser() *schema.Resource {
 				ForceNew:    true,
 				Description: "Boolean value indicating if the user is a MAAS administrator. Defaults to `false`.",
 			},
+			"is_local": {
+				Type:        schema.TypeBool,
+				Default:     true,
+				Computed:    true,
+				Description: "Boolean value indicating if the user is a local MAAS account. Defaults to `true`.",
+			},
 			"name": {
 				Type:        schema.TypeString,
 				Required:    true,
@@ -64,6 +71,11 @@ func resourceMAASUser() *schema.Resource {
 				Sensitive:   true,
 				ForceNew:    true,
 				Description: "The user password.",
+			},
+			"transfer_to_user": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "If provided, resources owned by the deleted user will be transfered to this user. ",
 			},
 		},
 	}
@@ -79,14 +91,27 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, meta any) d
 
 	d.SetId(user.UserName)
 
-	return nil
+	return resourceUserRead(ctx, d, meta)
 }
 
 func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*ClientConfig).Client
 
-	if _, err := client.User.Get(d.Id()); err != nil {
+	userName := d.Id()
+
+	user, err := client.User.Get(userName)
+	if err != nil {
 		return diag.FromErr(err)
+	}
+
+	tfState := map[string]interface{}{
+		"email":    user.Email,
+		"is_admin": user.IsSuperUser,
+		"is_local": user.IsLocal,
+		"name":     user.UserName,
+	}
+	if err := setTerraformState(d, tfState); err != nil {
+		return diag.Errorf("Could not set user state: %v", err)
 	}
 
 	return nil
@@ -95,7 +120,24 @@ func resourceUserRead(ctx context.Context, d *schema.ResourceData, meta any) dia
 func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
 	client := meta.(*ClientConfig).Client
 
-	if err := client.User.Delete(d.Id()); err != nil {
+	deleteParams := entity.UserDeleteParams{
+		UserName: d.Id(),
+	}
+
+	if user, ok := d.GetOk("transfer_to_user"); ok {
+		transferUserName := user.(string)
+		if transferUserName != "" {
+
+			transferUser, err := getUser(client, transferUserName)
+			if err != nil {
+				return diag.Errorf("user %q to transfer resources to doesn't exist: %v", transferUserName, err)
+			}
+
+			deleteParams.TransferResourcesTo = transferUser.UserName
+		}
+	}
+
+	if err := client.User.Delete(&deleteParams); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/maas/resource_maas_user.go
+++ b/maas/resource_maas_user.go
@@ -55,7 +55,6 @@ func resourceMAASUser() *schema.Resource {
 			},
 			"is_local": {
 				Type:        schema.TypeBool,
-				Default:     true,
 				Computed:    true,
 				Description: "Boolean value indicating if the user is a local MAAS account. Defaults to `true`.",
 			},
@@ -75,6 +74,7 @@ func resourceMAASUser() *schema.Resource {
 			"transfer_to_user": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				ForceNew:    true,
 				Description: "If provided, resources owned by the deleted user will be transfered to this user. ",
 			},
 		},
@@ -127,7 +127,6 @@ func resourceUserDelete(ctx context.Context, d *schema.ResourceData, meta any) d
 	if user, ok := d.GetOk("transfer_to_user"); ok {
 		transferUserName := user.(string)
 		if transferUserName != "" {
-
 			transferUser, err := getUser(client, transferUserName)
 			if err != nil {
 				return diag.Errorf("user %q to transfer resources to doesn't exist: %v", transferUserName, err)

--- a/maas/resource_maas_user_test.go
+++ b/maas/resource_maas_user_test.go
@@ -1,0 +1,155 @@
+package maas_test
+
+import (
+	"fmt"
+	"strings"
+	"terraform-provider-maas/maas"
+	"terraform-provider-maas/maas/testutils"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccResourceMAASUser_basic(t *testing.T) {
+	username1 := "testUser1"
+	password1 := "password1"
+	email1 := "testuser1@email.com"
+
+	username2 := "testUser2"
+	password2 := "password2"
+	email2 := "testuser2@email.com"
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.TestAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		ErrorCheck:   func(err error) error { return err },
+		Steps: []resource.TestStep{
+			// Test initial creation
+			{
+				Config: testAccUser(username1, password1, email1, true) + testAccUserTransfer(username2, password2, email2, false, username1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("maas_user.test_testUser1"),
+					testAccCheckUserExists("maas_user.test_testUser2"),
+
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "name", username1),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "is_admin", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "is_local", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "email", email1),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "password", password1),
+					resource.TestCheckNoResourceAttr("maas_user.test_testUser1", "transfer_to_user"),
+
+					resource.TestCheckResourceAttr("maas_user.test_testUser2", "name", username2),
+					resource.TestCheckResourceAttr("maas_user.test_testUser2", "is_admin", fmt.Sprintf("%t", false)),
+					resource.TestCheckResourceAttr("maas_user.test_testUser2", "is_local", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("maas_user.test_testUser2", "email", email2),
+					resource.TestCheckResourceAttr("maas_user.test_testUser2", "password", password2),
+					resource.TestCheckResourceAttr("maas_user.test_testUser2", "transfer_to_user", username1),
+				),
+			},
+			// Test deletion with transfer
+			{
+				Config: testAccUser(username1, password1, email1, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("maas_user.test_testUser1"),
+
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "name", username1),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "is_admin", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "is_local", fmt.Sprintf("%t", true)),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "email", email1),
+					resource.TestCheckResourceAttr("maas_user.test_testUser1", "password", password1),
+					resource.TestCheckNoResourceAttr("maas_user.test_testUser1", "transfer_to_user"),
+				),
+			},
+			// Test import
+			{
+				ResourceName:            "maas_user.test_testUser1",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["maas_user.test_testUser1"]
+					if !ok {
+						return "", fmt.Errorf("resource not found: maas_user.test_testUser1")
+					}
+
+					if rs.Primary.ID == "" {
+						return "", fmt.Errorf("resource id not set")
+					}
+					return rs.Primary.ID, nil
+				},
+			},
+		},
+	})
+}
+
+func testAccUser(username string, password string, email string, isAdmin bool) string {
+	return fmt.Sprintf(`
+resource "maas_user" "test_%v" {
+  name     = %q
+  password = %q
+  email    = %q
+  is_admin = %t
+}`, username, username, password, email, isAdmin)
+}
+
+func testAccUserTransfer(username string, password string, email string, isAdmin bool, transfer string) string {
+	return fmt.Sprintf(`
+resource "maas_user" "test_%v" {
+  name     = %q
+  password = %q
+  email    = %q
+  is_admin = %t
+
+  transfer_to_user = %q
+}`, username, username, password, email, isAdmin, transfer)
+}
+
+func testAccCheckUserExists(rn string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s\n %#v", rn, s.RootModule().Resources)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource id not set")
+		}
+
+		conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
+		_, err := conn.User.Get(rs.Primary.ID)
+		if err != nil {
+			return fmt.Errorf("error getting the user: %s", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckUserDestroy(s *terraform.State) error {
+	conn := testutils.TestAccProvider.Meta().(*maas.ClientConfig).Client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "maas_user" {
+			continue
+		}
+
+		id := rs.Primary.ID
+
+		response, err := conn.User.Get(id)
+		if err == nil {
+			if response != nil && response.UserName == id {
+				return fmt.Errorf("User %q still exists.", response.UserName)
+			}
+		}
+
+		// 404 means destroyed, anything else is an error
+		if !strings.Contains(err.Error(), "404 Not Found") {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Description of changes

<!-- A clear and concise description of your changes here. -->

Adds the missing user fields to the user endpoints, and implements testing for the user resource.

Users may now define a `transfer_to_user` resource, as per MAAS user delete.
Additionally the field `is_local` is populated, as per MAAS return.

User read now correctly sets the terraform state of the object, as per current practices.

## Issue or ticket link (if applicable)

<!-- 
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->
Requires: https://github.com/canonical/gomaasclient/pull/134

(implements the missing user fields at the gomaasclient layer)

## Checklist

- [x] I have written a PR title that follows the advice in DEVELOPMENT.md with the title format `type: title`
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [ ] I have run the unit tests and they pass.
- [ ] I have run the acceptance tests and they pass.
