### PR TITLE
fix: allow dns_servers to be a computed field

### DIFF
--- a/docs/resources/subnet.md
+++ b/docs/resources/subnet.md
@@ -59,7 +59,7 @@ resource "maas_subnet" "tf_subnet_2" {
 
 - `allow_dns` (Boolean) Boolean value that indicates if the MAAS DNS resolution is enabled for this subnet. Defaults to `true`.
 - `allow_proxy` (Boolean) Boolean value that indicates if `maas-proxy` allows requests from this subnet. Defaults to `true`.
-- `dns_servers` (List of String) List of IP addresses set as DNS servers for the new subnet. This argument is computed if it's not set.
+- `dns_servers` (List of String) List of IP addresses set as DNS servers for the new subnet. If this argument is omitted, it is computed from MAAS and left unmanaged. Set it explicitly to `[]` to remove all DNS servers from the subnet.
 - `fabric` (String) The fabric identifier (ID or name) for the new subnet. This argument is computed if it's not set.
 - `gateway_ip` (String) Gateway IP address for the new subnet. This argument is computed if it's not set.
 - `ip_ranges` (Block Set, Deprecated) A set of IP ranges configured on the new subnet. Parameters defined below. This argument is processed in [attribute-as-blocks mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html). (see [below for nested schema](#nestedblock--ip_ranges))

--- a/maas/resource_maas_subnet.go
+++ b/maas/resource_maas_subnet.go
@@ -21,7 +21,6 @@ func resourceMAASSubnet() *schema.Resource {
 		ReadContext:   resourceSubnetRead,
 		UpdateContext: resourceSubnetUpdate,
 		DeleteContext: resourceSubnetDelete,
-		CustomizeDiff: customizeDiffSubnet,
 		Importer: &schema.ResourceImporter{
 			StateContext: func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
 				client := meta.(*ClientConfig).Client
@@ -59,7 +58,7 @@ func resourceMAASSubnet() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
-				Description: "List of IP addresses set as DNS servers for the new subnet. This argument is computed if it's not set.",
+				Description: "List of IP addresses set as DNS servers for the new subnet. If this argument is omitted, it is computed from MAAS and left unmanaged. Set it explicitly to `[]` to remove all DNS servers from the subnet.",
 				Elem: &schema.Schema{
 					ValidateDiagFunc: isElementIPAddress,
 					Type:             schema.TypeString,
@@ -178,8 +177,8 @@ func resourceSubnetRead(ctx context.Context, d *schema.ResourceData, meta any) d
 	// Handle potential "<nil>" value from net.IP
 	gatewayIP := ipToString(subnet.GatewayIP)
 
-	// Populate dns_servers from MAAS
-	// CustomizeDiff will handle detecting when it should be cleared
+	// Populate dns_servers from MAAS. When the argument is omitted from the
+	// configuration it is computed, so whatever MAAS reports is authoritative.
 	dnsServers := make([]string, len(subnet.DNSServers))
 	for i, ip := range subnet.DNSServers {
 		dnsServers[i] = ipToString(ip)
@@ -385,29 +384,28 @@ func getSubnetParams(client *client.Client, d *schema.ResourceData) (*entity.Sub
 		Managed:    true,
 	}
 
-	// Handle dns_servers: distinguish between not set, empty list, and with values
-	// Check both raw config and HasChange (CustomizeDiff may force changes)
-	dnsServersInConfig := false
-
-	rawConfig := d.GetRawConfig()
-	if !rawConfig.IsNull() {
-		dnsServersInConfig = !rawConfig.GetAttr("dns_servers").IsNull()
-	}
-
-	// If explicitly in config OR CustomizeDiff detected removal and forced a change
-	if dnsServersInConfig || (d.Id() != "" && d.HasChange("dns_servers")) {
-		dnsServers := convertToStringSlice(d.Get("dns_servers"))
-		if len(dnsServers) == 0 {
-			// Empty list in config → send single empty string to clear values in MAAS
-			// MAAS API requires dns_servers="" (not omitted) to clear DNS servers
-			params.DNSServers = []string{""}
-		} else {
-			// Non-empty list → send the values
-			params.DNSServers = dnsServers
+	// There are three cases for dns_servers, to distinguish them we need GetRawConfig
+	// because d.Get cannot tell an explicit empty list apart from an unset one on an
+	// Optional+Computed attribute:
+	//
+	//	omitted     -> computed; the field is not sent, so MAAS keeps whatever it has
+	//	[]          -> clear every DNS server on the subnet
+	//	[a, b, ...] -> set those DNS servers
+	//
+	// The omitted cases is required to keep the dns_servers field a computed field, to
+	// avoid breaking changes to the provider
+	if rawConfig := d.GetRawConfig(); !rawConfig.IsNull() {
+		// isNull=False and isKnown=True means the attribute was set in the configuration, even if it was an empty list
+		if dnsServers := rawConfig.GetAttr("dns_servers"); !dnsServers.IsNull() && dnsServers.IsKnown() {
+			if dnsServers.LengthInt() == 0 {
+				// User has specified [], tell MAAS to remove all dns servers by sending a list with empty string
+				params.DNSServers = []string{""}
+			} else {
+				// User has specified a list of DNS servers
+				params.DNSServers = convertToStringSlice(d.Get("dns_servers"))
+			}
 		}
 	}
-	// If dns_servers is not set in config and no change detected, don't include it in params
-	// This lets MAAS use its defaults on creation
 
 	if p, ok := d.GetOk("fabric"); ok {
 		fabric, err := getFabric(client, p.(string))
@@ -457,24 +455,4 @@ func getSubnet(client *client.Client, identifier string) (*entity.Subnet, error)
 	}
 
 	return subnet, nil
-}
-
-func customizeDiffSubnet(ctx context.Context, diff *schema.ResourceDiff, meta any) error {
-	// Check if dns_servers is in the config
-	rawConfig := diff.GetRawConfig()
-	if !rawConfig.IsNull() {
-		// If dns_servers is not in config but exists in state (has a value), force it to be cleared
-		if rawConfig.GetAttr("dns_servers").IsNull() {
-			if oldDNS, _ := diff.GetOk("dns_servers"); oldDNS != nil {
-				if len(oldDNS.([]any)) > 0 {
-					// User removed dns_servers from config - set to empty list to trigger update
-					if err := diff.SetNew("dns_servers", []any{}); err != nil {
-						return err
-					}
-				}
-			}
-		}
-	}
-
-	return nil
 }

--- a/maas/resource_maas_subnet_test.go
+++ b/maas/resource_maas_subnet_test.go
@@ -328,6 +328,94 @@ resource "maas_subnet" "test_subnet" {
 	})
 }
 
+// Test the three possible uses of the dns_servers argument:
+//   - omitted from config     -> computed, MAAS's value is left untouched
+//   - explicitly set to []    -> every DNS server is removed from the subnet
+//   - explicitly set to a list -> those DNS servers are set
+func TestAccResourceMAASSubnet_dnsServersTriState(t *testing.T) {
+	subnetName := acctest.RandomWithPrefix("test-subnet-dns")
+	subnetAttrName := "maas_subnet.test_subnet_dns"
+	cidr := testutils.GenerateRandomCIDR()
+
+	withDNS := fmt.Sprintf(`
+resource "maas_subnet" "test_subnet_dns" {
+  cidr        = %q
+  name        = %q
+  dns_servers = ["1.1.1.1", "8.8.8.8"]
+}
+`, cidr, subnetName)
+
+	omitted := fmt.Sprintf(`
+resource "maas_subnet" "test_subnet_dns" {
+  cidr = %q
+  name = %q
+}
+`, cidr, subnetName)
+
+	emptied := fmt.Sprintf(`
+resource "maas_subnet" "test_subnet_dns" {
+  cidr        = %q
+  name        = %q
+  dns_servers = []
+}
+`, cidr, subnetName)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:     func() { testutils.PreCheck(t, nil) },
+		Providers:    testutils.TestAccProviders,
+		CheckDestroy: testAccCheckMAASSubnetDestroy,
+		ErrorCheck:   func(err error) error { return err },
+		Steps: []resource.TestStep{
+			// Explicit values are set.
+			{
+				Config: withDNS,
+				Check: resource.ComposeTestCheckFunc(
+					testAccMAASSubnetCheckExists(subnetAttrName),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.1", "8.8.8.8"),
+				),
+			},
+			// Removing the argument is a no-op: the value becomes computed and
+			// the servers configured above are preserved, not cleared.
+			{
+				Config: omitted,
+				Check: resource.ComposeTestCheckFunc(
+					testAccMAASSubnetCheckExists(subnetAttrName),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.#", "2"),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.0", "1.1.1.1"),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.1", "8.8.8.8"),
+				),
+			},
+			// The config above must be stable, i.e. no plan expected.
+			{
+				Config:   omitted,
+				PlanOnly: true,
+			},
+			// An explicit empty list is what actually clears the DNS servers.
+			{
+				Config: emptied,
+				Check: resource.ComposeTestCheckFunc(
+					testAccMAASSubnetCheckExists(subnetAttrName),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.#", "0"),
+				),
+			},
+			{
+				Config:   emptied,
+				PlanOnly: true,
+			},
+			// They can be set again afterwards.
+			{
+				Config: withDNS,
+				Check: resource.ComposeTestCheckFunc(
+					testAccMAASSubnetCheckExists(subnetAttrName),
+					resource.TestCheckResourceAttr(subnetAttrName, "dns_servers.#", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceMAASSubnet_ipRangesLifecycle(t *testing.T) {
 	subnetName := acctest.RandomWithPrefix("test-subnet")
 	subnetAttrName := "maas_subnet.test_subnet"


### PR DESCRIPTION
## Description of changes

In https://github.com/canonical/terraform-provider-maas/pull/446 , the behaviour introduced introduces a breaking change. `dns_servers` no longer acted as a `Computed` field, despite being labelled as one. This change was never released so there is no issue associated with it. This PR fixes this, by allowing a user to remove all dns_servers from their subnet by explicitly setting `dns_servers=[]` as before, but when omitted from the plan, allows a user to remove `dns_servers` from their resource and it to become a computed field.

This allows this to be a non-breaking change, as users upgrading won't have a non-empty plan. 

Please see the comments below for additional explanation and QA.

## Issue or ticket link (if applicable)

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->
NA

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
