### PR TITLE
fix: include missing bmc types in the validation list

### DIFF
--- a/maas/resource_maas_machine.go
+++ b/maas/resource_maas_machine.go
@@ -201,9 +201,10 @@ func resourceMAASMachine() *schema.Resource {
 				Description: "A power management type (e.g. `ipmi`).",
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(
 					[]string{
-						"amt", "apc", "dli", "eaton", "hmc", "ipmi", "manual", "moonshot",
-						"mscm", "msftocs", "nova", "openbmc", "proxmox", "recs_box", "redfish",
-						"sm15k", "ucsm", "vmware", "webhook", "wedge", "lxd", "virsh",
+						"amt", "apc", "dli", "eaton", "hmc", "hmcz", "ipmi", "lxd",
+						"manual", "moonshot", "mscm", "msftocs", "nova", "openbmc",
+						"proxmox", "raritan", "recs_box", "redfish", "sm15k", "ucsm",
+						"virsh", "vmware", "webhook", "wedge",
 					},
 					false)),
 			},
@@ -245,6 +246,13 @@ func resourceMAASMachine() *schema.Resource {
 			Update: schema.DefaultTimeout(30 * time.Minute),
 		},
 		CustomizeDiff: func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+			if d.Get("power_type").(string) == "nova" {
+				err := checkSemverConstraint(meta.(*ClientConfig).MAASVersion, "<3.8.0")
+				if err != nil {
+					return err
+				}
+			}
+
 			isDPU, ok := d.GetOk("is_dpu")
 			if !ok {
 				return nil


### PR DESCRIPTION
## Description of changes

- Extend the BMC validation list to include all supported MAAS BMC types (`hmcz`, `raritan`)
- Add an extra validation for `nova` type, so that the provider is rejecting it if MAAS version is >= 3.8, when that BMC type was removed

<!-- A clear and concise description of your changes here. -->

## Issue or ticket link (if applicable)

<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->
Resolves: #483

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
