### PR TITLE
chore: update Go linter and fix deprecation warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Go lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.6.2
+          version: v2.13
           # Note: By default, the `.golangci.yml` file should be at the root of the repository.
           # The location of the configuration file can be changed by using `--config=`
           # args: --timeout=30m --config=/my/path/.golangci.yml --issues-exit-code=0

--- a/maas/data_source_maas_boot_resources_test.go
+++ b/maas/data_source_maas_boot_resources_test.go
@@ -22,10 +22,10 @@ func TestAccDataSourceMAASBootResources_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BOOT_RESOURCES_OS"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: func(s *terraform.State) error { return nil },
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BOOT_RESOURCES_OS"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      func(s *terraform.State) error { return nil },
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASBootResources(resourcesRelease),

--- a/maas/data_source_maas_boot_source_selection_test.go
+++ b/maas/data_source_maas_boot_source_selection_test.go
@@ -26,10 +26,10 @@ func TestAccDataSourceMAASBootSourceSelection_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASBootSourceSelectionDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASBootSourceSelectionDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASBootSourceSelection(os, release, arches),

--- a/maas/data_source_maas_boot_source_test.go
+++ b/maas/data_source_maas_boot_source_test.go
@@ -32,10 +32,10 @@ func TestAccDataSourceMAASBootSource_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: func(s *terraform.State) error { return nil },
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      func(s *terraform.State) error { return nil },
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASBootSource(),

--- a/maas/data_source_maas_configuration_test.go
+++ b/maas/data_source_maas_configuration_test.go
@@ -22,10 +22,10 @@ func TestAccDataSourceMAASConfiguration_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccMAASConfigurationCheckDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccMAASConfigurationCheckDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASConfiguration(key, value),

--- a/maas/data_source_maas_device_test.go
+++ b/maas/data_source_maas_device_test.go
@@ -35,10 +35,10 @@ func TestAccDataSourceMAASDevice_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASDeviceDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASDeviceDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASDevice(description, domain, hostname, zone, macAddress),

--- a/maas/data_source_maas_devices_test.go
+++ b/maas/data_source_maas_devices_test.go
@@ -38,9 +38,9 @@ func TestAccDataSourceMAASDevices_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { testutils.PreCheck(t, nil) },
-		Providers:  testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASDevices(),

--- a/maas/data_source_maas_machine_test.go
+++ b/maas/data_source_maas_machine_test.go
@@ -18,9 +18,9 @@ func TestAccDataSourceMAASMachine_basic(t *testing.T) {
 	testMachineName := acctest.RandomWithPrefix("tf-acc-ds-machine")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
-		Providers:  testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASMachineVMHostConfig(vmHostID, testMachineName),

--- a/maas/data_source_maas_machines_test.go
+++ b/maas/data_source_maas_machines_test.go
@@ -38,9 +38,9 @@ func TestAccDataSourceMAASMachines_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { testutils.PreCheck(t, nil) },
-		Providers:  testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASMachines(),

--- a/maas/data_source_maas_package_repository_test.go
+++ b/maas/data_source_maas_package_repository_test.go
@@ -27,10 +27,10 @@ func TestAccDataSourceMAASPackageRepository_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: func(s *terraform.State) error { return nil },
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      func(s *terraform.State) error { return nil },
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASPackageRepository(resourceName),

--- a/maas/data_source_maas_rack_controller_test.go
+++ b/maas/data_source_maas_rack_controller_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestAccDataSourceMAASRackController_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { testutils.PreCheck(t, nil) },
-		Providers:  testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccDataSourceMAASRackController("rack-controller"),

--- a/maas/data_source_maas_rack_controllers_test.go
+++ b/maas/data_source_maas_rack_controllers_test.go
@@ -18,9 +18,9 @@ func TestAccDataSourceMAASRackControllers_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:   func() { testutils.PreCheck(t, nil) },
-		Providers:  testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASRackControllers(),

--- a/maas/data_source_maas_resource_pool_test.go
+++ b/maas/data_source_maas_resource_pool_test.go
@@ -23,10 +23,10 @@ func TestAccDataSourceMAASResourcePool_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASResourcePoolDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASResourcePoolDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASResourcePool(description, name),

--- a/maas/data_source_maas_vm_host_test.go
+++ b/maas/data_source_maas_vm_host_test.go
@@ -35,10 +35,10 @@ func testAccDataSourceMAASVMHost(t *testing.T, vmHostType string, additionalChec
 	checks = append(checks, additionalChecks...)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASVMHostDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASVMHostDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASVMHostConfig(vmHostID, vmHostMachineName, vmHostType),

--- a/maas/data_source_maas_zone_test.go
+++ b/maas/data_source_maas_zone_test.go
@@ -23,10 +23,10 @@ func TestAccDataSourceMAASZone_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASZoneDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASZoneDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASZone(description, name),

--- a/maas/resource_maas_block_device_tag_test.go
+++ b/maas/resource_maas_block_device_tag_test.go
@@ -24,10 +24,10 @@ func TestAccBlockDeviceTag_basic(t *testing.T) {
 	tagName3 := acctest.RandomWithPrefix("tf-tag")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASBlockDeviceTagDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASBlockDeviceTagDestroy,
 		Steps: []resource.TestStep{
 			// Test create.
 			{

--- a/maas/resource_maas_block_device_test.go
+++ b/maas/resource_maas_block_device_test.go
@@ -131,10 +131,10 @@ func TestAccResourceMAASBlockDevice_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: func(s *terraform.State) error { return nil },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      func(s *terraform.State) error { return nil },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASBlockDevice(machine),
@@ -152,10 +152,10 @@ func TestAccResourceMAASBlockDevice_stale(t *testing.T) {
 	idPath := acctest.RandomWithPrefix("/dev/vd")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASBlockDeviceDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASBlockDeviceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASBlockDeviceWithIDPath(machine, oldName, idPath),

--- a/maas/resource_maas_boot_source_selection_test.go
+++ b/maas/resource_maas_boot_source_selection_test.go
@@ -34,10 +34,10 @@ func TestAccResourceMAASBootSourceSelection_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASBootSourceSelectionDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASBootSourceSelectionDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test creation
 			{
@@ -86,10 +86,10 @@ func TestAccResourceMAASBootSourceSelection_defaultCommissioningAdoption(t *test
 	var bootSourceSelection entity.BootSourceSelection
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASBootSourceSelectionDefaultStillExists,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASBootSourceSelectionDefaultStillExists,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASBootSourceSelectionDefaultCommissioning([]string{"amd64", "ppc64el"}),

--- a/maas/resource_maas_boot_source_test.go
+++ b/maas/resource_maas_boot_source_test.go
@@ -29,10 +29,10 @@ func TestAccResourceMAASBootSource_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASBootSourceDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASBootSourceDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASBootSource(url, snapKeyring),

--- a/maas/resource_maas_configuration_test.go
+++ b/maas/resource_maas_configuration_test.go
@@ -375,10 +375,10 @@ func TestAccResourceMAASConfiguration_basic(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.key, func(t *testing.T) {
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_CONFIGURATION_DISTRO_SERIES"}) },
-				Providers:    testutils.TestAccProviders,
-				ErrorCheck:   func(err error) error { return err },
-				CheckDestroy: testAccMAASConfigurationCheckDestroy,
+				PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_CONFIGURATION_DISTRO_SERIES"}) },
+				ProviderFactories: testutils.TestAccProviderFactories,
+				ErrorCheck:        func(err error) error { return err },
+				CheckDestroy:      testAccMAASConfigurationCheckDestroy,
 				Steps: []resource.TestStep{
 					{
 						Config: testAccMAASConfigurationConfigBasic(testCase.key, testCase.value1),

--- a/maas/resource_maas_device_test.go
+++ b/maas/resource_maas_device_test.go
@@ -38,10 +38,10 @@ func TestAccResourceMAASDevice_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASDeviceDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASDeviceDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASDevice(description, domain, hostname, zone, macAddress),
@@ -95,10 +95,10 @@ func TestAccResourceMAASDevice_update(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASDeviceDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASDeviceDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASDeviceNetworkInterfaceConfig(deviceHostname, macAddress, fabricName, subnetCIDR, subnetName, subnetGatewayIP, linkIPAddress),

--- a/maas/resource_maas_dns_record_test.go
+++ b/maas/resource_maas_dns_record_test.go
@@ -26,10 +26,10 @@ func TestAccResourceMAASDNSRecord_basic(t *testing.T) {
 	testRecordType := "A/AAAA"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccMAASDNSRecordCheckDestroy(testIPAddress),
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccMAASDNSRecordCheckDestroy(testIPAddress),
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: getDNSRecordConfigBasic(recordName, testRecordType, testIPAddress, testDomain),
@@ -57,10 +57,10 @@ func TestAccResourceMAASDNSRecord_sameIPAddress(t *testing.T) {
 	testDomain := acctest.RandomWithPrefix("tf")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccMAASDNSRecordCheckDestroy(testIPAddress),
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccMAASDNSRecordCheckDestroy(testIPAddress),
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: getDNSRecordConfigSameIPAAAA(testDomain, resourceName1, resourceName2, recordName1, recordName2, testIPAddress),

--- a/maas/resource_maas_instance_test.go
+++ b/maas/resource_maas_instance_test.go
@@ -28,10 +28,10 @@ func TestAccResourceMAASInstance_releaseScripts(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccMAASInstanceCheckDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccMAASInstanceCheckDestroy,
 		Steps: []resource.TestStep{
 			// Test creation
 			{
@@ -78,10 +78,10 @@ func TestAccResourceMAASInstance_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccMAASInstanceCheckDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccMAASInstanceCheckDestroy,
 		Steps: []resource.TestStep{
 			// Test creation
 			{

--- a/maas/resource_maas_logical_volume_test.go
+++ b/maas/resource_maas_logical_volume_test.go
@@ -32,10 +32,10 @@ func TestAccResourceMAASLogicalVolume_basic(t *testing.T) {
 	changedSize := 2
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckLogicalVolumeDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckLogicalVolumeDestroy,
 		Steps: []resource.TestStep{
 			// Test initial creation
 			{
@@ -77,10 +77,10 @@ func TestAccResourceMAASLogicalVolume_formatAndMount(t *testing.T) {
 	test2MountPoint := ""
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckLogicalVolumeDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckLogicalVolumeDestroy,
 		Steps: []resource.TestStep{
 			// Test 1: `fs_type` not specified
 			{

--- a/maas/resource_maas_machine_test.go
+++ b/maas/resource_maas_machine_test.go
@@ -64,10 +64,10 @@ func TestAccResourceMAASMachine_Lookup(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_MACHINE_HOSTNAME"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: func(s *terraform.State) error { return nil },
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_MACHINE_HOSTNAME"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      func(s *terraform.State) error { return nil },
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceMAASMachineLookup(hostname, macAddress1, nicName1, macAddress2, nicName2),
@@ -83,9 +83,9 @@ func TestAccResourceMAASMachine_NoPXE(t *testing.T) {
 	testIPMIIP := "10.0.0.10"
 
 	resource.ParallelTest(t, resource.TestCase{
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: func(s *terraform.State) error { return nil },
-		ErrorCheck:   func(err error) error { return err },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      func(s *terraform.State) error { return nil },
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccMAASMachineLXDNoPXE(testLXDIP),

--- a/maas/resource_maas_network_interface_bond.go
+++ b/maas/resource_maas_network_interface_bond.go
@@ -21,7 +21,7 @@ func resourceMAASNetworkInterfaceBond() *schema.Resource {
 		UpdateContext: resourceNetworkInterfaceBondUpdate,
 		DeleteContext: resourceNetworkInterfaceBondDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceNetworkInterfaceBondImport,
+			StateContext: resourceNetworkInterfaceBondImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"accept_ra": {
@@ -323,7 +323,7 @@ func findBondParentsID(client *client.Client, machineSystemID string, parents []
 	return result, nil
 }
 
-func resourceNetworkInterfaceBondImport(d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+func resourceNetworkInterfaceBondImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), ":")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected MACHINE:BOND_INTERFACE_ID", d.Id())

--- a/maas/resource_maas_network_interface_bond_test.go
+++ b/maas/resource_maas_network_interface_bond_test.go
@@ -122,10 +122,10 @@ func TestAccResourceMAASNetworkInterfaceBond_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASNetworkInterfaceBondDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASNetworkInterfaceBondDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASNetworkInterfaceBond(name, parentNameOne, parentNameTwo, machine, macAddress, macAddressPhysOne, macAddressPhysTwo, 1500),

--- a/maas/resource_maas_network_interface_bridge.go
+++ b/maas/resource_maas_network_interface_bridge.go
@@ -20,7 +20,7 @@ func resourceMAASNetworkInterfaceBridge() *schema.Resource {
 		UpdateContext: resourceNetworkInterfaceBridgeUpdate,
 		DeleteContext: resourceNetworkInterfaceBridgeDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceNetworkInterfaceBridgeImport,
+			StateContext: resourceNetworkInterfaceBridgeImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"accept_ra": {
@@ -263,7 +263,7 @@ func findInterfaceParent(client *client.Client, machineSystemID string, parent s
 	return networkInterface.ID, nil
 }
 
-func resourceNetworkInterfaceBridgeImport(d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+func resourceNetworkInterfaceBridgeImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), ":")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected MACHINE:BRIDGE_INTERFACE_ID", d.Id())

--- a/maas/resource_maas_network_interface_bridge_test.go
+++ b/maas/resource_maas_network_interface_bridge_test.go
@@ -94,10 +94,10 @@ func TestAccResourceMAASNetworkInterfaceBridge_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASNetworkInterfaceBridgeDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASNetworkInterfaceBridgeDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASNetworkInterfaceBridge(name, parentName, machine, macAddress, macAddressPhys, 1500),

--- a/maas/resource_maas_network_interface_link_test.go
+++ b/maas/resource_maas_network_interface_link_test.go
@@ -122,10 +122,10 @@ func TestAccResourceMAASNetworkInterfaceLink_device(t *testing.T) {
 	ipAddress := testutils.GetNetworkPrefixFromCIDR(cidr) + ".42"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: func(s *terraform.State) error { return nil },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      func(s *terraform.State) error { return nil },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASNetworkInterfaceLinkDevice(macAddress, randomName, cidr, gateway, ipAddress),
@@ -157,10 +157,10 @@ func TestAccResourceMAASNetworkInterfaceLink_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: func(s *terraform.State) error { return nil },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      func(s *terraform.State) error { return nil },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASNetworkInterfaceLink(machine, cidr, gateway, "30.30.30.2", macAddress),

--- a/maas/resource_maas_network_interface_physical_test.go
+++ b/maas/resource_maas_network_interface_physical_test.go
@@ -78,10 +78,10 @@ func TestAccResourceMAASNetworkInterfacePhysical_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASNetworkInterfacePhysicalDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASNetworkInterfacePhysicalDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				// Pass the dynamic fabric name into the config generator

--- a/maas/resource_maas_network_interface_tag_test.go
+++ b/maas/resource_maas_network_interface_tag_test.go
@@ -36,10 +36,10 @@ func TestAccNetworkInterfaceTag_basic(t *testing.T) {
 	tagName2 := acctest.RandomWithPrefix("tag")
 	tagName3 := acctest.RandomWithPrefix("tag")
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASNetworkInterfaceDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			// Test creation.
 			{

--- a/maas/resource_maas_network_interface_vlan.go
+++ b/maas/resource_maas_network_interface_vlan.go
@@ -19,7 +19,7 @@ func resourceMAASNetworkInterfaceVLAN() *schema.Resource {
 		UpdateContext: resourceNetworkInterfaceVLANUpdate,
 		DeleteContext: resourceNetworkInterfaceVLANDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceNetworkInterfaceVLANImport,
+			StateContext: resourceNetworkInterfaceVLANImport,
 		},
 		Schema: map[string]*schema.Schema{
 			"accept_ra": {
@@ -234,7 +234,7 @@ func getNetworkInterfaceVLANUpdateParams(d *schema.ResourceData, parentID int, v
 	}
 }
 
-func resourceNetworkInterfaceVLANImport(d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
+func resourceNetworkInterfaceVLANImport(ctx context.Context, d *schema.ResourceData, m any) ([]*schema.ResourceData, error) {
 	idParts := strings.Split(d.Id(), ":")
 	if len(idParts) != 2 || idParts[0] == "" || idParts[1] == "" {
 		return nil, fmt.Errorf("unexpected format of ID (%q), expected MACHINE:VLAN_INTERFACE_ID", d.Id())

--- a/maas/resource_maas_network_interface_vlan_test.go
+++ b/maas/resource_maas_network_interface_vlan_test.go
@@ -92,10 +92,10 @@ func TestAccResourceMAASNetworkInterfaceVLAN_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASNetworkInterfaceVLANDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_NETWORK_INTERFACE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASNetworkInterfaceVLANDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASNetworkInterfaceVLAN(machine, name, parentName, macAddressPhys, 1500),

--- a/maas/resource_maas_node_script_test.go
+++ b/maas/resource_maas_node_script_test.go
@@ -136,10 +136,10 @@ func TestAccResourceMAASNodeScript_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASNodeScriptDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASNodeScriptDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASNodeScript(encodedScript),

--- a/maas/resource_maas_package_repository_test.go
+++ b/maas/resource_maas_package_repository_test.go
@@ -53,10 +53,10 @@ func TestAccResourceMAASPackageRepository_basic(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckPackageRepositoryDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckPackageRepositoryDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test creation of custom repo
 			{
@@ -144,10 +144,10 @@ func TestAccResourceMAASPackageRepository_validation(t *testing.T) {
 	)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckPackageRepositoryDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckPackageRepositoryDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test security repo, disabled, with no architectures listed
 			{

--- a/maas/resource_maas_raid_test.go
+++ b/maas/resource_maas_raid_test.go
@@ -49,10 +49,10 @@ func TestAccResourceMAASRAID_basic(t *testing.T) {
 		testAccRAIDPartition(blockDevice4Name, 2, false)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheclMAASRAIDDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheclMAASRAIDDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test initial creation
 			{
@@ -163,10 +163,10 @@ func TestAccResourceMAASRAID_formatAndMount(t *testing.T) {
 		testAccRAIDPartition(blockDevice4Name, 2, false)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheclMAASRAIDDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheclMAASRAIDDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test initial creation
 			{
@@ -223,10 +223,10 @@ func TestAccResourceMAASRAID_differentLevels(t *testing.T) {
 			blockDevice4Name := fmt.Sprintf("raid_level_%s_test_bd4", thisLevel)
 
 			resource.Test(t, resource.TestCase{
-				PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-				Providers:    testutils.TestAccProviders,
-				CheckDestroy: testAccCheclMAASRAIDDestroy,
-				ErrorCheck:   func(err error) error { return err },
+				PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+				ProviderFactories: testutils.TestAccProviderFactories,
+				CheckDestroy:      testAccCheclMAASRAIDDestroy,
+				ErrorCheck:        func(err error) error { return err },
 				Steps: []resource.TestStep{
 					{
 						Config: testAccRAIDMachine(machine) +

--- a/maas/resource_maas_reserved_ip_test.go
+++ b/maas/resource_maas_reserved_ip_test.go
@@ -25,10 +25,10 @@ func TestAccResourceMAASReservedIP_basic(t *testing.T) {
 	attrName := "maas_reserved_ip.test"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASReservedIPDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASReservedIPDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test create
 			{
@@ -141,10 +141,10 @@ func TestAccResourceMAASReservedIP_noSubnetField(t *testing.T) {
 	attrName := "maas_reserved_ip.test_no_subnet"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASReservedIPDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASReservedIPDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Create without explicit subnet
 			{

--- a/maas/resource_maas_resource_pool_test.go
+++ b/maas/resource_maas_resource_pool_test.go
@@ -27,10 +27,10 @@ func TestAccResourceMAASResourcePool_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASResourcePoolDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASResourcePoolDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASResourcePool(description, name),

--- a/maas/resource_maas_ssh_keys_test.go
+++ b/maas/resource_maas_ssh_keys_test.go
@@ -94,10 +94,10 @@ func TestAccResourceMAASSSHKey_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASSSHKeyDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASSSHKeyDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASSSHKeyConfig(singleKey),

--- a/maas/resource_maas_static_route_test.go
+++ b/maas/resource_maas_static_route_test.go
@@ -40,9 +40,9 @@ func TestAccStaticRoute_basic(t *testing.T) {
 	resource.ParallelTest(t, resource.TestCase{
 		// boilerplate every basic test has, we provide basic pre-check and error check
 		// as our test doesn't require anything fancy
-		PreCheck:   func() { testutils.PreCheck(t, nil) },
-		Providers:  testutils.TestAccProviders,
-		ErrorCheck: func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
 		// When the test concludes we'll need to test the resources are correctly destroyed
 		CheckDestroy: testAccCheckMAASStaticRouteDestroy,
 		// We define the tests that will be run against our resource

--- a/maas/resource_maas_subnet_ip_range_test.go
+++ b/maas/resource_maas_subnet_ip_range_test.go
@@ -40,10 +40,10 @@ func TestAccResourceMAASSubnetIPRange_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASSubnetIPRangeDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASSubnetIPRangeDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test creation
 			{

--- a/maas/resource_maas_subnet_test.go
+++ b/maas/resource_maas_subnet_test.go
@@ -73,10 +73,10 @@ func TestAccResourceMAASSubnet_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASSubnetDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASSubnetDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test creation
 			{
@@ -304,10 +304,10 @@ func TestAccResourceMAASSubnet_computedFabricVlan(t *testing.T) {
 	cidr := testutils.GenerateRandomCIDR()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASSubnetDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASSubnetDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(`
@@ -361,10 +361,10 @@ resource "maas_subnet" "test_subnet_dns" {
 `, cidr, subnetName)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASSubnetDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASSubnetDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Explicit values are set.
 			{
@@ -424,10 +424,10 @@ func TestAccResourceMAASSubnet_ipRangesLifecycle(t *testing.T) {
 	prefix := testutils.GetNetworkPrefixFromCIDR(cidr)
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASSubnetDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASSubnetDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Step 1: Create subnet with one inline range
 			{

--- a/maas/resource_maas_tag_test.go
+++ b/maas/resource_maas_tag_test.go
@@ -31,10 +31,10 @@ func TestAccResourceMAASTag_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_TAG_MACHINES"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASTagDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_TAG_MACHINES"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASTagDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASTag(name, comment, machines),

--- a/maas/resource_maas_user_test.go
+++ b/maas/resource_maas_user_test.go
@@ -21,10 +21,10 @@ func TestAccResourceMAASUser_basic(t *testing.T) {
 	email2 := "testuser2@email.com"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckUserDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckUserDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test initial creation
 			{

--- a/maas/resource_maas_vlan_dhcp_test.go
+++ b/maas/resource_maas_vlan_dhcp_test.go
@@ -25,10 +25,10 @@ func TestAccMAASVLANDHCP_basic(t *testing.T) {
 	rackController := os.Getenv("TF_ACC_RACK_CONTROLLER_HOSTNAME")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASVLANDHCPDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASVLANDHCPDestroy,
 		Steps: []resource.TestStep{
 			// Test create.
 			{
@@ -77,10 +77,10 @@ func TestAccMAASVLANDHCP_wrongIPRange(t *testing.T) {
 	startIP2, endIP2 := networkPrefix2+".2", networkPrefix2+".5"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASVLANDHCPDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASVLANDHCPDestroy,
 		Steps: []resource.TestStep{
 			// Test error on create.
 			{
@@ -104,10 +104,10 @@ func TestAccMAASVLANDHCP_subnet(t *testing.T) {
 	cidrForSubnetUpdate := testutils.GenerateRandomCIDR()
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASVLANDHCPDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASVLANDHCPDestroy,
 		Steps: []resource.TestStep{
 			// Test create.
 			{
@@ -143,10 +143,10 @@ func TestAccMAASVLANDHCP_relay(t *testing.T) {
 	rackController := os.Getenv("TF_ACC_RACK_CONTROLLER_HOSTNAME")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASVLANDHCPDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASVLANDHCPDestroy,
 		Steps: []resource.TestStep{
 			// Test create.
 			{
@@ -175,10 +175,10 @@ func TestAccMAASVLANDHCP_relayVLANUpdateCycle(t *testing.T) {
 	rackController := os.Getenv("TF_ACC_RACK_CONTROLLER_HOSTNAME")
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
-		Providers:    testutils.TestAccProviders,
-		ErrorCheck:   func(err error) error { return err },
-		CheckDestroy: testAccCheckMAASVLANDHCPDestroy,
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_RACK_CONTROLLER_HOSTNAME"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		ErrorCheck:        func(err error) error { return err },
+		CheckDestroy:      testAccCheckMAASVLANDHCPDestroy,
 		Steps: []resource.TestStep{
 			// Step 1: Start with primary rack controller DHCP
 			{

--- a/maas/resource_maas_vm_host_test.go
+++ b/maas/resource_maas_vm_host_test.go
@@ -23,10 +23,10 @@ func TestAccMAASVMHost_DeployParams(t *testing.T) {
 	vmHostType := "lxd"
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASVMHostDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_VM_HOST_ID"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASVMHostDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASVMHostDeployParamsConfig(vmHostIdentifier, testMachineName, vmHostType),

--- a/maas/resource_maas_volume_group_test.go
+++ b/maas/resource_maas_volume_group_test.go
@@ -27,10 +27,10 @@ func TestAccResourceMAASVolumeGroup_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASVolumeGroupDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, []string{"TF_ACC_BLOCK_DEVICE_MACHINE"}) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASVolumeGroupDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			// Test initial creation
 			{

--- a/maas/resource_maas_zone_test.go
+++ b/maas/resource_maas_zone_test.go
@@ -28,10 +28,10 @@ func TestAccResourceMAASZone_basic(t *testing.T) {
 	}
 
 	resource.ParallelTest(t, resource.TestCase{
-		PreCheck:     func() { testutils.PreCheck(t, nil) },
-		Providers:    testutils.TestAccProviders,
-		CheckDestroy: testAccCheckMAASZoneDestroy,
-		ErrorCheck:   func(err error) error { return err },
+		PreCheck:          func() { testutils.PreCheck(t, nil) },
+		ProviderFactories: testutils.TestAccProviderFactories,
+		CheckDestroy:      testAccCheckMAASZoneDestroy,
+		ErrorCheck:        func(err error) error { return err },
 		Steps: []resource.TestStep{
 			{
 				Config: testAccMAASZone(name, description),

--- a/maas/testutils/provider.go
+++ b/maas/testutils/provider.go
@@ -9,14 +9,16 @@ import (
 )
 
 var (
-	TestAccProviders map[string]*schema.Provider
-	TestAccProvider  *schema.Provider
+	TestAccProvider          *schema.Provider
+	TestAccProviderFactories map[string]func() (*schema.Provider, error)
 )
 
 func init() {
 	TestAccProvider = maas.Provider()
-	TestAccProviders = map[string]*schema.Provider{
-		"maas": TestAccProvider,
+	TestAccProviderFactories = map[string]func() (*schema.Provider, error){
+		"maas": func() (*schema.Provider, error) {
+			return TestAccProvider, nil
+		},
 	}
 }
 


### PR DESCRIPTION
## Description of changes

- Update golangci-lint to the latest available version
- Fix deprecation warnings that are detected after the upgrade
- Allow the CI to run with go.mod pointing up to Go 1.27 due to the golangci-lint version bump

<!-- A clear and concise description of your changes here. -->

## Issue or ticket link (if applicable)

N/A
<!--
Please link the issue this PR addresses using GitHub’s keywords to automatically close related issues. See https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword

e.g. Resolves: #XXX -->

## Checklist

- [x] I have written a PR title that follows the advice in CONTRIBUTING.md
- [x] I have written a description of the changes in the PR that is clear and concise.
- [x] I have updated the documentation to reflect the changes.
- [x] I have added or updated the tests to reflect the changes.
- [x] I have run the unit tests and they pass.
- [x] I have run the acceptance tests and they pass.
